### PR TITLE
Error when calling schema generation with introspection query

### DIFF
--- a/Sources/GraphQL/Type/Directives.swift
+++ b/Sources/GraphQL/Type/Directives.swift
@@ -107,7 +107,7 @@ let GraphQLSkipDirective = try! GraphQLDirective(
 /**
  * Constant string used for default reason for a deprecation.
  */
-let defaulDeprecationReason: Map = .string("No longer supported")
+let defaulDeprecationReason: Map = .string("\"No longer supported\"")
 
 /**
  * Used to declare element of a GraphQL schema as deprecated.


### PR DESCRIPTION
I'm trying to generate code with apollo-codegen. I received an error with the schema.json generated.

Syntax Error GraphQL (1:4) Expected <EOF>, found Name "longer"

1: No longer supported

