### PR TITLE
Prevent Token linked list from leaking.

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -92,7 +92,7 @@ final class Token {
      * including ignored tokens. <SOF> is always the first node and <EOF>
      * the last.
      */
-    let prev: Token?
+    weak var prev: Token?
     var next: Token?
 
     init(kind: Kind, start: Int, end: Int, line: Int, column: Int, value: String? = nil, prev: Token? = nil, next: Token? = nil) {


### PR DESCRIPTION
Token ownership is now only from the parent `Token` to its `next` `Token`. This allows ARC to be able to free tokens once they are no longer used. Without this `schema.execute(...)` will continue to eat memory without giving it back as queries are served.

Hopefully no unwanted side effects to this small update. 