### PR TITLE
Make GraphQLUnionType init public

### DIFF
--- a/Sources/GraphQL/Type/Definition.swift
+++ b/Sources/GraphQL/Type/Definition.swift
@@ -698,7 +698,7 @@ public final class GraphQLUnionType {
     let types: [GraphQLObjectType]
     let possibleTypeNames: [String: Bool]
 
-    init(
+    public init(
         name: String,
         description: String? = nil,
         resolveType: GraphQLTypeResolve? = nil,


### PR DESCRIPTION
Required for GraphQLSwift/Graphiti#10 to build.