### PR TITLE
Introduce persisted queries

### DIFF
--- a/Sources/GraphQL/PersistedQueries/DictionaryPersistedQueries.swift
+++ b/Sources/GraphQL/PersistedQueries/DictionaryPersistedQueries.swift
@@ -1,0 +1,40 @@
+
+/// A simple PersistedQueries implementation
+public struct DictionaryPersistedQueries<IdType: Hashable>: PersistQueryExecution {
+    public typealias Id = IdType
+
+    let schema: GraphQLSchema
+    let queries: [Id: Document]
+
+    /// - Parameters:
+    ///   - schema: The GraphQL type system to use when validating and executing a query.
+    ///   - sources: A dictionary of sources that make up the persisted queries.
+    /// - Throws: throws GraphQLError if an error occurs while parsing and validating the persistant queries.
+    public init(schema: GraphQLSchema, sources: [Id: Source]) throws {
+        var queries: [Id: Document] = [:]
+        try sources.forEach { id, source in
+            let documentAST = try parse(source: source)
+            let validationErrors = validate(schema: schema, ast: documentAST)
+            if let firstError = validationErrors.first {
+                throw firstError
+            }
+            queries[id] = documentAST
+        }
+        self.schema = schema
+        self.queries = queries
+    }
+
+    public func execute(id: Id, rootValue: Any, contextValue: Any, variableValues: [String: Map], operationName: String?) throws -> Map {
+        guard let documentAST = queries[id] else {
+            throw GraphQLError(message: "Unknown query \"\(id)\".")
+        }
+        return try GraphQL.execute(
+            schema: schema,
+            documentAST: documentAST,
+            rootValue: rootValue,
+            contextValue: contextValue,
+            variableValues: variableValues,
+            operationName: operationName
+        )
+    }
+}

--- a/Sources/GraphQL/PersistedQueries/PersistedQueries.swift
+++ b/Sources/GraphQL/PersistedQueries/PersistedQueries.swift
@@ -1,0 +1,21 @@
+/// Protocol to provide support for executing persist queries.
+public protocol PersistQueryExecution {
+    associatedtype Id
+    ///
+    /// - parameter id:             The id of the persistant query that you want to execute.
+    /// - parameter rootValue:      The value provided as the first argument to resolver functions on the top level type (e.g. the query object type).
+    /// - parameter contextValue:   A context value provided to all resolver functions functions
+    /// - parameter variableValues: A mapping of variable name to runtime value to use for all variables defined in the `request`.
+    /// - parameter operationName:  The name of the operation to use if `request` contains multiple possible operations. Can be omitted if `request` contains only one operation.
+    ///
+    /// - throws: throws GraphQLError if an error occurs while loading that persistant query.
+    ///
+    /// - returns: returns a `Map` dictionary containing the result of the query inside the key `data` and any validation or execution errors inside the key `errors`. The value of `data` might be `null` if, for example, the query is invalid. It's possible to have both `data` and `errors` if an error occurs only in a specific field. If that happens the value of that field will be `null` and there will be an error inside `errors` specifying the reason for the failure and the path of the failed field.
+    func execute(id: Id, rootValue: Any, contextValue: Any, variableValues: [String: Map], operationName: String?) throws -> Map
+}
+
+public extension PersistQueryExecution {
+    func execute(id: Id, rootValue: Any = Void(), contextValue: Any = Void(), variableValues: [String: Map] = [:], operationName: String? = nil) throws -> Map {
+        return try execute(id: id, rootValue: rootValue, contextValue: contextValue, variableValues: variableValues, operationName: operationName)
+    }
+}

--- a/Tests/GraphQLTests/PersistedQueries/DictionaryPersistedQueriesTests.swift
+++ b/Tests/GraphQLTests/PersistedQueries/DictionaryPersistedQueriesTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import GraphQL
+
+class DictionaryPersistedQueriesTests : XCTestCase {
+    let schema = try! GraphQLSchema(
+        query: GraphQLObjectType(
+            name: "RootQueryType",
+            fields: [
+                "hello": GraphQLField(
+                    type: GraphQLString,
+                    resolve: { _ in "world" }
+                )
+            ]
+        )
+    )
+
+    let sources: [Int: Source] = [
+        42: Source(body: "{ hello }", name: "Hello GraphQL")
+    ]
+
+    func testKnownId() throws {
+        let queries = try DictionaryPersistedQueries<Int>(schema: schema, sources: sources)
+        let expected: Map = [
+            "data": [
+                "hello": "world"
+            ]
+        ]
+        let result = try queries.execute(id: 42)
+        XCTAssertEqual(result, expected)
+    }
+
+    func testUnknownId() throws {
+        let queries = try DictionaryPersistedQueries<Int>(schema: schema, sources: sources)
+        XCTAssertThrowsError(try queries.execute(id: 29)) { error in
+            guard let error = error as? GraphQLError else {
+                return XCTFail()
+            }
+            XCTAssert(error.message.contains(
+                "Unknown query \"29\"."
+            ))
+        }
+    }
+
+    func testWithInvalidSource() throws {
+        let brokenSource: [Int: Source] = [
+            91: Source(body: "{ hello ", name: "broken Hello GraphQL")
+        ]
+        XCTAssertThrowsError(
+            try DictionaryPersistedQueries<Int>(schema: schema, sources: brokenSource)
+        ) { error in
+            guard let error = error as? GraphQLError else {
+                return XCTFail()
+            }
+            XCTAssert(error.message.contains(
+                "Syntax Error broken Hello GraphQL (1:9) Expected Name, found <EOF>"
+            ))
+        }
+    }
+}
+
+extension DictionaryPersistedQueriesTests {
+    static var allTests: [(String, (DictionaryPersistedQueriesTests) -> () throws -> Void)] {
+        return [
+            ("testKnownId", testKnownId),
+            ("testUnknownId", testUnknownId),
+            ("testWithInvalidSource", testWithInvalidSource),
+        ]
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -10,4 +10,5 @@ XCTMain([
      testCase(LexerTests.allTests),
      testCase(ParserTests.allTests),
      testCase(SchemaParserTests.allTests),
+     testCase(DictionaryPersistedQueriesTests.allTests),
 ])


### PR DESCRIPTION
Introduce the ability to support having persisted queries. The implementation is simple however its not something that anybody can really implement outside of this module given the visibility of things like `Document`, `parse`, and `validate` .