### PR TITLE
Concurrent field resolution using Dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GraphQL 
+# GraphQL
 
 The Swift implementation for GraphQL, a query language for APIs created by Facebook.
 
@@ -36,7 +36,7 @@ import PackageDescription
 
 let package = Package(
     dependencies: [
-        .Package(url: "https://github.com/GraphQLSwift/GraphQL.git", majorVersion: 0, minor: 2),
+        .Package(url: "https://github.com/GraphQLSwift/GraphQL.git", majorVersion: 0),
     ]
 )
 ```
@@ -104,12 +104,35 @@ Output:
                     "line": 1,
                     "column": 3
                 }
-            ], 
+            ],
             "message": "Cannot query field \"boyhowdy\" on type \"RootQueryType\"."
         }
     ]
 }
 ```
+
+### Field Execution Strategies
+
+Depending on your needs you can alter the field execution strategies used for field value resolution.
+
+By default the `SerialFieldExecutionStrategy` is used for all operation types (`query`, `mutation`, `subscription`).
+
+To use a different strategy simply provide it to the `graphql` function:
+
+```swift
+try graphql(
+    queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
+    schema: schema,
+    request: query
+)
+```
+
+The following strategies are available:
+
+* `SerialFieldExecutionStrategy`
+* `ConcurrentDispatchFieldExecutionStrategy`
+
+**Please note:** Not all strategies are applicable for all operation types.
 
 ## License
 

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -20,9 +20,9 @@
 ///
 /// - returns: returns a `Map` dictionary containing the result of the query inside the key `data` and any validation or execution errors inside the key `errors`. The value of `data` might be `null` if, for example, the query is invalid. It's possible to have both `data` and `errors` if an error occurs only in a specific field. If that happens the value of that field will be `null` and there will be an error inside `errors` specifying the reason for the failure and the path of the failed field.
 public func graphql(
-    queryStrategy: FieldExecutionStrategy = SerialFieldExecutionStrategy(),
-    mutationStrategy: FieldExecutionStrategy = SerialFieldExecutionStrategy(),
-    subscriptionStrategy: FieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    queryStrategy: QueryFieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    mutationStrategy: MutationFieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    subscriptionStrategy: SubscriptionFieldExecutionStrategy = SerialFieldExecutionStrategy(),
     schema: GraphQLSchema,
     request: String,
     rootValue: Any = Void(),

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -289,16 +289,16 @@ func == (lhs: Definition, rhs: Definition) -> Bool {
     return false
 }
 
-enum OperationType : String {
+public enum OperationType : String {
     case query = "query"
     case mutation = "mutation"
     // Note: subscription is an experimental non-spec addition.
     case subscription = "subscription"
 }
 
-final class OperationDefinition {
-    let kind: Kind = .operationDefinition
-    let loc: Location?
+public final class OperationDefinition {
+    public let kind: Kind = .operationDefinition
+    public let loc: Location?
     let operation: OperationType
     let name: Name?
     let variableDefinitions: [VariableDefinition]
@@ -314,7 +314,7 @@ final class OperationDefinition {
         self.selectionSet = selectionSet
     }
 
-    func get(key: String) -> NodeResult? {
+    public func get(key: String) -> NodeResult? {
         switch key {
         case "name":
             return name.map({ .node($0) })
@@ -337,11 +337,11 @@ final class OperationDefinition {
 }
 
 extension OperationDefinition : Hashable {
-    var hashValue: Int {
+    public var hashValue: Int {
         return ObjectIdentifier(self).hashValue
     }
 
-    static func == (lhs: OperationDefinition, rhs: OperationDefinition) -> Bool {
+    public static func == (lhs: OperationDefinition, rhs: OperationDefinition) -> Bool {
         return lhs.operation == rhs.operation &&
             lhs.name == rhs.name &&
             lhs.variableDefinitions == rhs.variableDefinitions &&
@@ -673,9 +673,9 @@ extension InlineFragment : Equatable {
     }
 }
 
-final class FragmentDefinition {
-    let kind: Kind = .fragmentDefinition
-    let loc: Location?
+public final class FragmentDefinition {
+    public let kind: Kind = .fragmentDefinition
+    public let loc: Location?
     let name: Name
     let typeCondition: NamedType
     let directives: [Directive]
@@ -689,7 +689,7 @@ final class FragmentDefinition {
         self.selectionSet = selectionSet
     }
 
-    func get(key: String) -> NodeResult? {
+    public func get(key: String) -> NodeResult? {
         switch key {
         case "name":
             return .node(name)
@@ -709,11 +709,11 @@ final class FragmentDefinition {
 }
 
 extension FragmentDefinition : Hashable {
-    var hashValue: Int {
+    public var hashValue: Int {
         return ObjectIdentifier(self).hashValue
     }
 
-    static func == (lhs: FragmentDefinition, rhs: FragmentDefinition) -> Bool {
+    public static func == (lhs: FragmentDefinition, rhs: FragmentDefinition) -> Bool {
         return lhs.name == rhs.name &&
         lhs.typeCondition == rhs.typeCondition &&
         lhs.directives == rhs.directives &&

--- a/Sources/GraphQL/Type/Definition.swift
+++ b/Sources/GraphQL/Type/Definition.swift
@@ -452,11 +452,11 @@ public typealias GraphQLFieldResolve = (
 ) throws -> Any?
 
 public struct GraphQLResolveInfo {
-    let fieldName: String
+    public let fieldName: String
     let fieldASTs: [Field]
     let returnType: GraphQLOutputType
     let parentType: GraphQLCompositeType
-    let path: [IndexPathElement]
+    public let path: [IndexPathElement]
     let schema: GraphQLSchema
     let fragments: [String: FragmentDefinition]
     let rootValue: Any

--- a/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
+++ b/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
@@ -1,0 +1,288 @@
+import Dispatch
+import GraphQL
+import XCTest
+
+class FieldExecutionStrategyTests: XCTestCase {
+
+    enum StrategyError: Error {
+        case exampleError(msg: String)
+    }
+
+    let schema = try! GraphQLSchema(
+        query: GraphQLObjectType(
+            name: "RootQueryType",
+            fields: [
+                "sleep": GraphQLField(
+                    type: GraphQLString,
+                    resolve: { _ in
+                        let g = DispatchGroup()
+                        g.enter()
+                        DispatchQueue.global().asyncAfter(wallDeadline: .now() + 0.1) {
+                            g.leave()
+                        }
+                        g.wait()
+                        return "z"
+                }
+                ),
+                "bang": GraphQLField(
+                    type: GraphQLString,
+                    resolve: { (_, _, _, info: GraphQLResolveInfo) in
+                        let g = DispatchGroup()
+                        g.enter()
+                        DispatchQueue.global().asyncAfter(wallDeadline: .now() + 0.1) {
+                            g.leave()
+                        }
+                        g.wait()
+                        throw StrategyError.exampleError(
+                            msg: "\(info.fieldName): \(info.path.last as! String)"
+                        )
+                }
+                )
+            ]
+        )
+    )
+
+    let singleQuery = "{ sleep }"
+    let singleExpected: Map = [
+        "data": [
+            "sleep": "z"
+        ]
+    ]
+
+    let multiQuery = "{ a: sleep b: sleep c: sleep d: sleep e: sleep f: sleep g: sleep h: sleep i: sleep j: sleep }"
+    let multiExpected: Map = [
+        "data": [
+            "a": "z",
+            "b": "z",
+            "c": "z",
+            "d": "z",
+            "e": "z",
+            "f": "z",
+            "g": "z",
+            "h": "z",
+            "i": "z",
+            "j": "z",
+        ]
+    ]
+
+    let singleThrowsQuery = "{ bang }"
+    let singleThrowsExpected: Map = [
+        "data": [
+            "bang": nil
+        ],
+        "errors": [
+            [
+                "locations": [
+                    ["column": 3, "line": 1]
+                ],
+                "message": "exampleError(\"bang: bang\")",
+                "path":["bang"]
+            ]
+        ]
+    ]
+
+    let multiThrowsQuery = "{ a: bang b: bang c: bang d: bang e: bang f: bang g: bang h: bang i: bang j: bang }"
+    let multiThrowsExpectedData: Map = [
+        "a": nil,
+        "b": nil,
+        "c": nil,
+        "d": nil,
+        "e": nil,
+        "f": nil,
+        "g": nil,
+        "h": nil,
+        "i": nil,
+        "j": nil,
+        ]
+    let multiThrowsExpectedErrors: [Map] = [
+        [
+            "locations": [
+                ["column": 3, "line": 1]
+            ],
+            "message": "exampleError(\"bang: a\")",
+            "path":["a"]
+        ],
+        [
+            "locations": [
+                ["column": 11, "line": 1]
+            ],
+            "message": "exampleError(\"bang: b\")",
+            "path":["b"]
+        ],
+        [
+            "locations": [
+                ["column": 19, "line": 1]
+            ],
+            "message": "exampleError(\"bang: c\")",
+            "path":["c"]
+        ],
+        [
+            "locations": [
+                ["column": 27, "line": 1]
+            ],
+            "message": "exampleError(\"bang: d\")",
+            "path":["d"]
+        ],
+        [
+            "locations": [
+                ["column": 35, "line": 1]
+            ],
+            "message": "exampleError(\"bang: e\")",
+            "path":["e"]
+        ],
+        [
+            "locations": [
+                ["column": 43, "line": 1]
+            ],
+            "message": "exampleError(\"bang: f\")",
+            "path":["f"]
+        ],
+        [
+            "locations": [
+                ["column": 51, "line": 1]
+            ],
+            "message": "exampleError(\"bang: g\")",
+            "path":["g"]
+        ],
+        [
+            "locations": [
+                ["column": 59, "line": 1]
+            ],
+            "message": "exampleError(\"bang: h\")",
+            "path":["h"]
+        ],
+        [
+            "locations": [
+                ["column": 67, "line": 1]
+            ],
+            "message": "exampleError(\"bang: i\")",
+            "path":["i"]
+        ],
+        [
+            "locations": [
+                ["column": 75, "line": 1]
+            ],
+            "message": "exampleError(\"bang: j\")",
+            "path":["j"]
+        ],
+        ]
+
+    func timing<T>(_ block: @autoclosure () throws -> T) throws -> (value: T, seconds: Double) {
+        let start = DispatchTime.now()
+        let value = try block()
+        let nanoseconds = DispatchTime.now().uptimeNanoseconds - start.uptimeNanoseconds
+        let seconds = Double(nanoseconds) / 1_000_000_000
+        return (
+            value: value,
+            seconds: seconds
+        )
+    }
+
+    func testSerialFieldExecutionStrategyWithSingleField() throws {
+        let result = try timing(try graphql(
+            queryStrategy: SerialFieldExecutionStrategy(),
+            schema: schema,
+            request: singleQuery
+            ))
+        XCTAssertEqual(result.value, singleExpected)
+        //XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+    }
+
+    func testSerialFieldExecutionStrategyWithSingleFieldError() throws {
+        let result = try timing(try graphql(
+            queryStrategy: SerialFieldExecutionStrategy(),
+            schema: schema,
+            request: singleThrowsQuery
+            ))
+        XCTAssertEqual(result.value, singleThrowsExpected)
+        //XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+    }
+
+    func testSerialFieldExecutionStrategyWithMultipleFields() throws {
+        let result = try timing(try graphql(
+            queryStrategy: SerialFieldExecutionStrategy(),
+            schema: schema,
+            request: multiQuery
+            ))
+        XCTAssertEqual(result.value, multiExpected)
+        //XCTAssertEqualWithAccuracy(1.0, result.seconds, accuracy: 0.5)
+    }
+
+    func testSerialFieldExecutionStrategyWithMultipleFieldErrors() throws {
+        let result = try timing(try graphql(
+            queryStrategy: SerialFieldExecutionStrategy(),
+            schema: schema,
+            request: multiThrowsQuery
+            ))
+        XCTAssertEqual(result.value["data"], multiThrowsExpectedData)
+        let resultErrors = try result.value["errors"].asArray()
+        XCTAssertEqual(resultErrors.count, multiThrowsExpectedErrors.count)
+        multiThrowsExpectedErrors.forEach { (m) in
+            XCTAssertTrue(resultErrors.contains(m), "Expecting result errors to contain \(m)")
+        }
+        //XCTAssertEqualWithAccuracy(1.0, result.seconds, accuracy: 0.5)
+    }
+
+    func testConcurrentDispatchFieldExecutionStrategyWithSingleField() throws {
+        let result = try timing(try graphql(
+            queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
+            schema: schema,
+            request: singleQuery
+            ))
+        XCTAssertEqual(result.value, singleExpected)
+        //XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+    }
+
+    func testConcurrentDispatchFieldExecutionStrategyWithSingleFieldError() throws {
+        let result = try timing(try graphql(
+            queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
+            schema: schema,
+            request: singleThrowsQuery
+            ))
+        XCTAssertEqual(result.value, singleThrowsExpected)
+        //XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+    }
+
+    func testConcurrentDispatchFieldExecutionStrategyWithMultipleFields() throws {
+        let result = try timing(try graphql(
+            queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
+            schema: schema,
+            request: multiQuery
+            ))
+        XCTAssertEqual(result.value, multiExpected)
+        //XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+    }
+
+    func testConcurrentDispatchFieldExecutionStrategyWithMultipleFieldErrors() throws {
+        let result = try timing(try graphql(
+            queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
+            schema: schema,
+            request: multiThrowsQuery
+            ))
+        XCTAssertEqual(result.value["data"], multiThrowsExpectedData)
+        let resultErrors = try result.value["errors"].asArray()
+        XCTAssertEqual(resultErrors.count, multiThrowsExpectedErrors.count)
+        multiThrowsExpectedErrors.forEach { (m) in
+            XCTAssertTrue(resultErrors.contains(m), "Expecting result errors to contain \(m)")
+        }
+        //XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+    }
+
+}
+
+extension FieldExecutionStrategyTests {
+    static var allTests: [(String, (FieldExecutionStrategyTests) -> () throws -> Void)] {
+        return [
+            ("testSerialFieldExecutionStrategyWithSingleField", testSerialFieldExecutionStrategyWithSingleField),
+            ("testSerialFieldExecutionStrategyWithSingleFieldError", testSerialFieldExecutionStrategyWithSingleFieldError),
+            ("testSerialFieldExecutionStrategyWithMultipleFields", testSerialFieldExecutionStrategyWithMultipleFields),
+            ("testSerialFieldExecutionStrategyWithMultipleFieldErrors", testSerialFieldExecutionStrategyWithMultipleFieldErrors),
+            ("testConcurrentDispatchFieldExecutionStrategyWithSingleField", testConcurrentDispatchFieldExecutionStrategyWithSingleField),
+            ("testConcurrentDispatchFieldExecutionStrategyWithSingleFieldError", testConcurrentDispatchFieldExecutionStrategyWithSingleFieldError),
+            ("testConcurrentDispatchFieldExecutionStrategyWithMultipleFields", testConcurrentDispatchFieldExecutionStrategyWithMultipleFields),
+            ("testConcurrentDispatchFieldExecutionStrategyWithMultipleFieldErrors", testConcurrentDispatchFieldExecutionStrategyWithMultipleFieldErrors),
+        ]
+    }
+}
+
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -10,4 +10,5 @@ XCTMain([
      testCase(LexerTests.allTests),
      testCase(ParserTests.allTests),
      testCase(SchemaParserTests.allTests),
+     testCase(FieldExecutionStrategyTests.allTests),
 ])


### PR DESCRIPTION
Use `DispatchQueue` and `DispatchGroup` to provide a simple implementation for concurrent field resolution. Some advantages to having a simple implementation is that we don't introduce any API changes and we can free the field resolvers from having to worry about things like promises and callback blocks at this point in time.

Unit tests have been added to verify the different behaviour between serial resolution (mutations) and concurrent resolution (queries). Not sure if using `usleep` is the best way to test concurrency and the `accuracy` value was pulled from thin air but it seems to work for me. I suppose CI might have different ideas.