### PR TITLE
Introduce the FieldExecutionStrategy protocol

### DIFF
--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -24,16 +24,23 @@
  * Namely, schema of the type system that is currently executing,
  * and the fragments defined in the query document
  */
-final class ExecutionContext {
-  let schema: GraphQLSchema
-  let fragments: [String: FragmentDefinition]
-  let rootValue: Any
-  let contextValue: Any
-  let operation: OperationDefinition
-  let variableValues: [String: Map]
-  var errors: [GraphQLError]
+public final class ExecutionContext {
+
+    let queryStrategy: FieldExecutionStrategy
+    let mutationStrategy: FieldExecutionStrategy
+    let subscriptionStrategy: FieldExecutionStrategy
+    let schema: GraphQLSchema
+    let fragments: [String: FragmentDefinition]
+    let rootValue: Any
+    let contextValue: Any
+    let operation: OperationDefinition
+    let variableValues: [String: Map]
+    var errors: [GraphQLError]
 
     init(
+        queryStrategy: FieldExecutionStrategy,
+        mutationStrategy: FieldExecutionStrategy,
+        subscriptionStrategy: FieldExecutionStrategy,
         schema: GraphQLSchema,
         fragments: [String: FragmentDefinition],
         rootValue: Any,
@@ -42,6 +49,9 @@ final class ExecutionContext {
         variableValues: [String: Map],
         errors: [GraphQLError]
     ) {
+        self.queryStrategy = queryStrategy
+        self.mutationStrategy = mutationStrategy
+        self.subscriptionStrategy = subscriptionStrategy
         self.schema = schema
         self.fragments = fragments
         self.rootValue = rootValue
@@ -53,6 +63,46 @@ final class ExecutionContext {
     }
 }
 
+public protocol FieldExecutionStrategy {
+    func executeFields(
+        exeContext: ExecutionContext,
+        parentType: GraphQLObjectType,
+        sourceValue: Any,
+        path: [IndexPathElement],
+        fields: [String: [Field]]
+    ) throws -> [String: Any]
+}
+
+/**
+ * Serial field execution strategy that's suitable for the "Evaluating selection sets" section of the spec for "write" mode.
+ */
+public struct SerialFieldExecutionStrategy: FieldExecutionStrategy {
+    public func executeFields(
+        exeContext: ExecutionContext,
+        parentType: GraphQLObjectType,
+        sourceValue: Any,
+        path: [IndexPathElement],
+        fields: [String: [Field]]
+    ) throws -> [String: Any] {
+        return try fields.reduce([:]) { results, field in
+            var results = results
+            let fieldASTs = field.value
+            let fieldPath = path + [field.key] as [IndexPathElement]
+
+            let result = try resolveField(
+                exeContext: exeContext,
+                parentType: parentType,
+                source: sourceValue,
+                fieldASTs: fieldASTs,
+                path: fieldPath
+            )
+
+            results[field.key] = result ?? Map.null
+            return results
+        }
+    }
+}
+
 /**
  * Implements the "Evaluating requests" section of the GraphQL specification.
  *
@@ -60,6 +110,9 @@ final class ExecutionContext {
  * a GraphQLError will be thrown immediately explaining the invalid input.
  */
 func execute(
+    queryStrategy: FieldExecutionStrategy,
+    mutationStrategy: FieldExecutionStrategy,
+    subscriptionStrategy: FieldExecutionStrategy,
     schema: GraphQLSchema,
     documentAST: Document,
     rootValue: Any,
@@ -70,6 +123,9 @@ func execute(
     // If a valid context cannot be created due to incorrect arguments,
     // this will throw an error.
     let context = try buildExecutionContext(
+        queryStrategy: queryStrategy,
+        mutationStrategy: mutationStrategy,
+        subscriptionStrategy: subscriptionStrategy,
         schema: schema,
         documentAST: documentAST,
         rootValue: rootValue,
@@ -110,6 +166,9 @@ func execute(
  * Throws a GraphQLError if a valid execution context cannot be created.
  */
 func buildExecutionContext(
+    queryStrategy: FieldExecutionStrategy,
+    mutationStrategy: FieldExecutionStrategy,
+    subscriptionStrategy: FieldExecutionStrategy,
     schema: GraphQLSchema,
     documentAST: Document,
     rootValue: Any,
@@ -160,6 +219,9 @@ func buildExecutionContext(
     )
     
     return ExecutionContext(
+        queryStrategy: queryStrategy,
+        mutationStrategy: mutationStrategy,
+        subscriptionStrategy: subscriptionStrategy,
         schema: schema,
         fragments: fragments,
         rootValue: rootValue,
@@ -193,17 +255,17 @@ func executeOperation(
 
     let path: [IndexPathElement] = []
 
-    if operation.operation == .mutation {
-        return try executeFieldsSerially(
-            exeContext: exeContext,
-            parentType: type,
-            sourceValue: rootValue,
-            path: path,
-            fields: fields
-        )
+    let fieldExecutionStrategy: FieldExecutionStrategy
+    switch operation.operation {
+    case .query:
+        fieldExecutionStrategy = exeContext.queryStrategy
+    case .mutation:
+        fieldExecutionStrategy = exeContext.mutationStrategy
+    case .subscription:
+        fieldExecutionStrategy = exeContext.subscriptionStrategy
     }
 
-    return try executeFields(
+    return try fieldExecutionStrategy.executeFields(
         exeContext: exeContext,
         parentType: type,
         sourceValue: rootValue,
@@ -241,55 +303,6 @@ func getOperationRootType(
 
       return subscriptionType
   }
-}
-
-/**
- * Implements the "Evaluating selection sets" section of the spec
- * for "write" mode.
- */
-func executeFieldsSerially(
-    exeContext: ExecutionContext,
-    parentType: GraphQLObjectType,
-    sourceValue: Any,
-    path: [IndexPathElement],
-    fields: [String: [Field]]
-) throws -> [String: Any] {
-    return try fields.reduce([:]) { results, field in
-        var results = results
-        let fieldASTs = field.value
-        let fieldPath = path + [field.key] as [IndexPathElement]
-
-        let result = try resolveField(
-            exeContext: exeContext,
-            parentType: parentType,
-            source: sourceValue,
-            fieldASTs: fieldASTs,
-            path: fieldPath
-        )
-
-        results[field.key] = result ?? Map.null
-        return results
-    }
-}
-
-/**
- * Implements the "Evaluating selection sets" section of the spec
- * for "read" mode.
- */
-func executeFields(
-    exeContext: ExecutionContext,
-    parentType: GraphQLObjectType,
-    sourceValue: Any,
-    path: [IndexPathElement],
-    fields: [String: [Field]]
-) throws -> [String : Any] {
-    return try executeFieldsSerially(
-        exeContext: exeContext,
-        parentType: parentType,
-        sourceValue: sourceValue,
-        path: path,
-        fields: fields
-    )
 }
 
 /**
@@ -911,8 +924,8 @@ func completeObjectValue(
             )
         }
     }
-    
-    return try executeFields(
+
+    return try exeContext.queryStrategy.executeFields(
         exeContext: exeContext,
         parentType: returnType,
         sourceValue: result,

--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -480,7 +480,7 @@ func getFieldEntryKey(node: Field) -> String {
  * then calls completeValue to complete promises, serialize scalars, or execute
  * the sub-selection-set for objects.
  */
-func resolveField(
+public func resolveField(
     exeContext: ExecutionContext,
     parentType: GraphQLObjectType,
     source: Any,

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -6,17 +6,23 @@
 /// may wish to separate the validation and execution phases to a static time
 /// tooling step, and a server runtime step.
 ///
-/// - parameter schema:         The GraphQL type system to use when validating and executing a query.
-/// - parameter request:        A GraphQL language formatted string representing the requested operation.
-/// - parameter rootValue:      The value provided as the first argument to resolver functions on the top level type (e.g. the query object type).
-/// - parameter contextValue:   A context value provided to all resolver functions functions
-/// - parameter variableValues: A mapping of variable name to runtime value to use for all variables defined in the `request`.
-/// - parameter operationName:  The name of the operation to use if `request` contains multiple possible operations. Can be omitted if `request` contains only one operation.
+/// - parameter queryStrategy:        The field execution strategy to use for query requests
+/// - parameter mutationStrategy:     The field execution strategy to use for mutation requests
+/// - parameter subscriptionStrategy: The field execution strategy to use for subscription requests
+/// - parameter schema:               The GraphQL type system to use when validating and executing a query.
+/// - parameter request:              A GraphQL language formatted string representing the requested operation.
+/// - parameter rootValue:            The value provided as the first argument to resolver functions on the top level type (e.g. the query object type).
+/// - parameter contextValue:         A context value provided to all resolver functions functions
+/// - parameter variableValues:       A mapping of variable name to runtime value to use for all variables defined in the `request`.
+/// - parameter operationName:        The name of the operation to use if `request` contains multiple possible operations. Can be omitted if `request` contains only one operation.
 ///
 /// - throws: throws GraphQLError if an error occurs while parsing the `request`.
 ///
 /// - returns: returns a `Map` dictionary containing the result of the query inside the key `data` and any validation or execution errors inside the key `errors`. The value of `data` might be `null` if, for example, the query is invalid. It's possible to have both `data` and `errors` if an error occurs only in a specific field. If that happens the value of that field will be `null` and there will be an error inside `errors` specifying the reason for the failure and the path of the failed field.
 public func graphql(
+    queryStrategy: FieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    mutationStrategy: FieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    subscriptionStrategy: FieldExecutionStrategy = SerialFieldExecutionStrategy(),
     schema: GraphQLSchema,
     request: String,
     rootValue: Any = Void(),
@@ -33,6 +39,9 @@ public func graphql(
     }
 
     return try execute(
+        queryStrategy: queryStrategy,
+        mutationStrategy: mutationStrategy,
+        subscriptionStrategy: subscriptionStrategy,
         schema: schema,
         documentAST: documentAST,
         rootValue: rootValue,

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -426,17 +426,17 @@ extension Variable : Equatable {
     }
 }
 
-final class SelectionSet {
-    let kind: Kind = .selectionSet
-    let loc: Location?
-    let selections: [Selection]
+public final class SelectionSet {
+    public let kind: Kind = .selectionSet
+    public let loc: Location?
+    public let selections: [Selection]
 
     init(loc: Location? = nil, selections: [Selection]) {
         self.loc = loc
         self.selections = selections
     }
 
-    func get(key: String) -> NodeResult? {
+    public func get(key: String) -> NodeResult? {
         switch key {
         case "selections":
             guard !selections.isEmpty else {
@@ -450,11 +450,11 @@ final class SelectionSet {
 }
 
 extension SelectionSet : Hashable {
-    var hashValue: Int {
+    public var hashValue: Int {
         return ObjectIdentifier(self).hashValue
     }
 
-    static func == (lhs: SelectionSet, rhs: SelectionSet) -> Bool {
+    public static func == (lhs: SelectionSet, rhs: SelectionSet) -> Bool {
         guard lhs.selections.count == rhs.selections.count else {
             return false
         }
@@ -469,10 +469,10 @@ extension SelectionSet : Hashable {
     }
 }
 
-protocol  Selection      : Node      {}
-extension Field          : Selection {}
-extension FragmentSpread : Selection {}
-extension InlineFragment : Selection {}
+public protocol Selection : Node      {}
+extension Field           : Selection {}
+extension FragmentSpread  : Selection {}
+extension InlineFragment  : Selection {}
 
 func == (lhs: Selection, rhs: Selection) -> Bool {
     switch lhs {
@@ -495,14 +495,14 @@ func == (lhs: Selection, rhs: Selection) -> Bool {
     return false
 }
 
-final class Field {
-    let kind: Kind = .field
-    let loc: Location?
-    let alias: Name?
-    let name: Name
-    let arguments: [Argument]
-    let directives: [Directive]
-    let selectionSet: SelectionSet?
+public final class Field {
+    public let kind: Kind = .field
+    public let loc: Location?
+    public let alias: Name?
+    public let name: Name
+    public let arguments: [Argument]
+    public let directives: [Directive]
+    public let selectionSet: SelectionSet?
 
     init(loc: Location? = nil, alias: Name? = nil, name: Name, arguments: [Argument] = [], directives: [Directive] = [], selectionSet: SelectionSet? = nil) {
         self.loc = loc
@@ -513,7 +513,7 @@ final class Field {
         self.selectionSet = selectionSet
     }
 
-    func get(key: String) -> NodeResult? {
+    public func get(key: String) -> NodeResult? {
         switch key {
         case "alias":
             return alias.map({ .node($0) })
@@ -538,7 +538,7 @@ final class Field {
 }
 
 extension Field : Equatable {
-    static func == (lhs: Field, rhs: Field) -> Bool {
+    public static func == (lhs: Field, rhs: Field) -> Bool {
         return lhs.alias == rhs.alias &&
             lhs.name == rhs.name &&
             lhs.arguments == rhs.arguments &&
@@ -547,11 +547,11 @@ extension Field : Equatable {
     }
 }
 
-final class Argument {
-    let kind: Kind = .argument
-    let loc: Location?
-    let name: Name
-    let value: Value
+public final class Argument {
+    public let kind: Kind = .argument
+    public let loc: Location?
+    public let name: Name
+    public let value: Value
 
     init(loc: Location? = nil, name: Name, value: Value) {
         self.loc = loc
@@ -559,7 +559,7 @@ final class Argument {
         self.value = value
     }
 
-    func get(key: String) -> NodeResult? {
+    public func get(key: String) -> NodeResult? {
         switch key {
         case "name":
             return .node(name)
@@ -572,7 +572,7 @@ final class Argument {
 }
 
 extension Argument : Equatable {
-    static func == (lhs: Argument, rhs: Argument) -> Bool {
+    public static func == (lhs: Argument, rhs: Argument) -> Bool {
         return lhs.name == rhs.name &&
             lhs.value == rhs.value
     }
@@ -921,11 +921,11 @@ extension ObjectField : Equatable {
     }
 }
 
-final class Directive {
-    let kind: Kind = .directive
-    let loc: Location?
-    let name: Name
-    let arguments: [Argument]
+public final class Directive {
+    public let kind: Kind = .directive
+    public let loc: Location?
+    public let name: Name
+    public let arguments: [Argument]
 
     init(loc: Location? = nil, name: Name, arguments: [Argument] = []) {
         self.loc = loc
@@ -935,7 +935,7 @@ final class Directive {
 }
 
 extension Directive : Equatable {
-    static func == (lhs: Directive, rhs: Directive) -> Bool {
+    public static func == (lhs: Directive, rhs: Directive) -> Bool {
         return lhs.name == rhs.name &&
             lhs.arguments == rhs.arguments
     }

--- a/Sources/GraphQL/Type/Definition.swift
+++ b/Sources/GraphQL/Type/Definition.swift
@@ -47,7 +47,7 @@ extension GraphQLNonNull          : GraphQLOutputType {}
 /**
  * These types may describe types which may be leaf values.
  */
-public protocol GraphQLLeafType : GraphQLType, GraphQLNamedType {
+public protocol GraphQLLeafType : GraphQLNamedType {
     func serialize(value: Any) throws -> Map
     func parseValue(value: Map) throws -> Map
     func parseLiteral(valueAST: Value) throws -> Map
@@ -65,10 +65,10 @@ func isLeafType(type: GraphQLType?) -> Bool {
 /**
  * These types may describe the parent context of a selection set.
  */
-public protocol GraphQLCompositeType : GraphQLType, GraphQLNamedType, GraphQLOutputType {}
-extension GraphQLObjectType          : GraphQLCompositeType                             {}
-extension GraphQLInterfaceType       : GraphQLCompositeType                             {}
-extension GraphQLUnionType           : GraphQLCompositeType                             {}
+public protocol GraphQLCompositeType : GraphQLNamedType, GraphQLOutputType {}
+extension GraphQLObjectType          : GraphQLCompositeType                {}
+extension GraphQLInterfaceType       : GraphQLCompositeType                {}
+extension GraphQLUnionType           : GraphQLCompositeType                {}
 
 protocol GraphQLTypeReferenceContainer : GraphQLNamedType {
     func replaceTypeReferences(typeMap: TypeMap) throws
@@ -80,7 +80,7 @@ extension GraphQLInterfaceType : GraphQLTypeReferenceContainer {}
 /**
  * These types may describe the parent context of a selection set.
  */
-public protocol GraphQLAbstractType : GraphQLType, GraphQLNamedType {
+public protocol GraphQLAbstractType : GraphQLNamedType {
     var resolveType: GraphQLTypeResolve? { get }
 }
 
@@ -110,7 +110,7 @@ func getNullableType(type: GraphQLType?) -> GraphQLNullableType? {
 /**
  * These named types do not include modifiers like List or NonNull.
  */
-public protocol GraphQLNamedType : GraphQLType, GraphQLNullableType, MapRepresentable {
+public protocol GraphQLNamedType : GraphQLNullableType {
     var name: String { get }
 }
 


### PR DESCRIPTION
Following up from the discussions in #13 this PR introduces the `FieldExecutionStrategy` protocol and the ability for users to specify how field execution should happen.

The introduction of the protocol has meant that quite a few more items have become `public` including the `resolveField` function. Although in the scope of this PR the `resolveField` function could remain hidden its functionality is required for any `FieldExecutionStrategy` implementation.