### PR TITLE
Fix bug where fragment definition type stack was not correctly set

### DIFF
--- a/Sources/GraphQL/Utilities/TypeInfo.swift
+++ b/Sources/GraphQL/Utilities/TypeInfo.swift
@@ -95,8 +95,8 @@ final class TypeInfo {
             typeStack.append(outputType as? GraphQLOutputType)
 
         case let node as FragmentDefinition:
-            let typeConditionAST = node.typeCondition
-            typeStack.append(typeConditionAST as? GraphQLOutputType)
+            let outputType = typeFromAST(schema: schema, inputTypeAST: node.typeCondition)
+            typeStack.append(outputType as? GraphQLOutputType)
 
         case let node as VariableDefinition:
             let inputType = typeFromAST(schema: schema, inputTypeAST: node.type)

--- a/Tests/GraphQLTests/ValidationTests/ExampleSchema.swift
+++ b/Tests/GraphQLTests/ValidationTests/ExampleSchema.swift
@@ -1,0 +1,169 @@
+@testable import GraphQL
+
+//
+// enum DogCommand { SIT, DOWN, HEEL }
+//
+let ValidationExampleDogCommand = try! GraphQLEnumType(
+    name: "DogCommand",
+    values: [
+        "SIT": GraphQLEnumValue(
+            value: "SIT"
+        ),
+        "DOWN": GraphQLEnumValue(
+            value: "DOWN"
+        ),
+        "HEEL": GraphQLEnumValue(
+            value: "HEEL"
+        ),
+    ]
+)
+
+// interface Sentient {
+//     name: String!
+// }
+let ValidationExampleSentient = try! GraphQLInterfaceType(
+    name: "Sentient",
+    fields: [
+        "name": GraphQLField(type: GraphQLNonNull(GraphQLString)),
+    ],
+    resolveType: { _, _, info in
+        return "Unknown"
+    }
+)
+
+// type Alien implements Sentient {
+//     name: String!
+//     homePlanet: String
+// }
+let ValidationExampleAlien = try! GraphQLObjectType(
+    name: "Alien",
+    fields: [
+        "name": GraphQLField(type: GraphQLNonNull(GraphQLString)),
+        "homePlanet": GraphQLField(type: GraphQLString),
+    ],
+    interfaces: [ValidationExampleSentient]
+)
+
+// type Human implements Sentient {
+//     name: String!
+//     pets: [Pet!]!
+// }
+let ValidationExampleHuman = try! GraphQLObjectType(
+    name: "Human",
+    fields: [
+        "name": GraphQLField(type: GraphQLNonNull(GraphQLString)),
+        "pets": GraphQLField(type: GraphQLNonNull(GraphQLList(GraphQLNonNull(ValidationExamplePet)))),
+    ],
+    interfaces: [ValidationExampleSentient]
+)
+
+// interface Pet {
+//     name: String!
+// }
+let ValidationExamplePet = try! GraphQLInterfaceType(
+    name: "Pet",
+    fields: [
+        "name": GraphQLField(type: GraphQLNonNull(GraphQLString)),
+    ],
+    resolveType: { _, _, _ in
+        return "Unknown"
+    }
+)
+
+// type Dog implements Pet {
+//     name: String!
+//     nickname: String
+//     barkVolume: Int
+//     doesKnowCommand(dogCommand: DogCommand!): Boolean!
+//     isHousetrained(atOtherHomes: Boolean): Boolean!
+//     owner: Human
+// }
+let ValidationExampleDog = try! GraphQLObjectType(
+    name: "Dog",
+    fields: [
+        "name": GraphQLField(type: GraphQLNonNull(GraphQLString)),
+        "nickname": GraphQLField(type: GraphQLString),
+        "barkVolume": GraphQLField(type: GraphQLInt),
+        "doesKnowCommand": GraphQLField(
+            type: GraphQLNonNull(GraphQLBoolean),
+            args: [
+                "dogCommand": GraphQLArgument(type: GraphQLNonNull(ValidationExampleDogCommand))
+            ]
+        ),
+        "isHousetrained": GraphQLField(
+            type: GraphQLNonNull(GraphQLBoolean),
+            args: [
+                "atOtherHomes": GraphQLArgument(type: GraphQLBoolean)
+            ]
+        ),
+        "owner": GraphQLField(type: ValidationExampleHuman),
+    ],
+    interfaces: [ValidationExamplePet]
+)
+
+// enum CatCommand { JUMP }
+let ValidationExampleCatCommand = try! GraphQLEnumType(
+    name: "CatCommand",
+    values: [
+        "JUMP": GraphQLEnumValue(
+            value: "JUMP"
+        ),
+    ]
+)
+
+// type Cat implements Pet {
+//     name: String!
+//     nickname: String
+//     doesKnowCommand(catCommand: CatCommand!): Boolean!
+//     meowVolume: Int
+// }
+let ValidationExampleCat = try! GraphQLObjectType(
+    name: "Cat",
+    fields: [
+        "name": GraphQLField(type: GraphQLNonNull(GraphQLString)),
+        "nickname": GraphQLField(type: GraphQLString),
+        "doesKnowCommand": GraphQLField(
+            type: GraphQLNonNull(GraphQLBoolean),
+            args: [
+                "catCommand": GraphQLArgument(type: GraphQLNonNull(ValidationExampleCatCommand))
+            ]
+        ),
+        "meowVolume": GraphQLField(type: GraphQLInt),
+    ],
+    interfaces: [ValidationExamplePet]
+)
+
+// union CatOrDog = Cat | Dog
+let ValidationExampleCatOrDog = try! GraphQLUnionType(
+    name: "CatOrDog",
+    types: [ValidationExampleCat, ValidationExampleDog]
+)
+
+// union DogOrHuman = Dog | Human
+let ValidationExampleDogOrHuman = try! GraphQLUnionType(
+    name: "DogOrHuman",
+    types: [ValidationExampleDog, ValidationExampleHuman]
+)
+
+// union HumanOrAlien = Human | Alien
+let ValidationExampleHumanOrAlien = try! GraphQLUnionType(
+    name: "HumanOrAlien",
+    types: [ValidationExampleHuman, ValidationExampleAlien]
+)
+
+// type QueryRoot {
+//   dog: Dog
+// }
+let ValidationExampleQueryRoot = try! GraphQLObjectType(
+    name: "QueryRoot",
+    fields: [
+        "dog": GraphQLField(type: ValidationExampleDog),
+    ]
+)
+
+let ValidationExampleSchema = try! GraphQLSchema(
+    query: ValidationExampleQueryRoot,
+    types: [
+        ValidationExampleDog,
+    ]
+)

--- a/Tests/GraphQLTests/ValidationTests/FieldsOnCorrectTypeTests.swift
+++ b/Tests/GraphQLTests/ValidationTests/FieldsOnCorrectTypeTests.swift
@@ -1,0 +1,209 @@
+@testable import GraphQL
+import XCTest
+
+class FieldsOnCorrectTypeTests : ValidationTestCase {
+
+    override func setUp() {
+        rule = FieldsOnCorrectType
+    }
+
+    func testValidWithObjectFieldSelection() throws {
+        try assertValid(
+            "fragment objectFieldSelection on Dog { __typename name }"
+        )
+    }
+
+    func testValidWithAliasedObjectFieldSelection() throws {
+        try assertValid(
+            "fragment aliasedObjectFieldSelection on Dog { tn : __typename otherName : name }"
+        )
+    }
+
+    func testValidWithInterfaceFieldSelection() throws {
+        try assertValid(
+            "fragment interfaceFieldSelection on Pet { __typename name }"
+        )
+    }
+
+    func testValidWithAliasedInterfaceFieldSelection() throws {
+        try assertValid(
+            "fragment aliasedInterfaceFieldSelection on Pet { otherName : name }"
+        )
+    }
+
+    func testValidWithLyingAliasSelection() throws {
+        try assertValid(
+            "fragment lyingAliasSelection on Dog { name : nickname }"
+        )
+    }
+
+    func testValidWithInlineFragment() throws {
+        try assertValid(
+            "fragment inlineFragment on Pet { ... on Dog { name } ... { name } }"
+        )
+    }
+
+    func testValidWhenMetaFieldSelectionOnUnion() throws {
+        try assertValid(
+            "fragment metaFieldSelectionOnUnion on CatOrDog { __typename }"
+        )
+    }
+
+    func testValidWithIgnoresFieldsOnUnknownType() throws {
+        try assertValid(
+            "fragment ignoresFieldsOnUnknownType on UnknownType { unknownField }"
+        )
+    }
+
+    func testInvalidWhenTypeKnownAgain() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment typeKnownAgain on Pet { unknown_pet_field { ... on Cat { unknown_cat_field } } }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 34,
+            message: "Cannot query field \"unknown_pet_field\" on type \"Pet\"."
+        )
+    }
+
+    func testInvalidWhenFieldNotDefined() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment fieldNotDefined on Dog { meowVolume }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 35,
+            message: "Cannot query field \"meowVolume\" on type \"Dog\". Did you mean \"barkVolume\"?"
+        )
+    }
+
+    func testInvalidWhenDeepFieldNotDefined() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment deepFieldNotDefined on Dog { unknown_field { deeper_unknown_field }}"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 39,
+            message: "Cannot query field \"unknown_field\" on type \"Dog\"."
+        )
+    }
+
+    func testInvalidWhenSubFieldNotDefined() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment subFieldNotDefined on Human { pets { unknown_field } }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 47,
+            message: "Cannot query field \"unknown_field\" on type \"Pet\"."
+        )
+    }
+
+    func testInvalidWhenFieldNotDefinedOnInlineFragment() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment fieldNotDefinedOnInlineFragment on Pet { ... on Dog { meowVolume } }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 64,
+            message: "Cannot query field \"meowVolume\" on type \"Dog\". Did you mean \"barkVolume\"?"
+        )
+    }
+
+    func testInvalidWhenAliasedFieldTargetNotDefined() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment aliasedFieldTargetNotDefined on Dog { volume : mooVolume }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 48,
+            message: "Cannot query field \"mooVolume\" on type \"Dog\". Did you mean \"barkVolume\"?"
+        )
+    }
+
+    func testInvalidWhenAliasedLyingFieldTargetNotDefined() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment aliasedLyingFieldTargetNotDefined on Dog { barkVolume : kawVolume }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 53,
+            message: "Cannot query field \"kawVolume\" on type \"Dog\". Did you mean \"barkVolume\"?"
+        )
+    }
+
+    func testInvalidWhenNotDefinedOnInterface() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment notDefinedOnInterface on Pet { tailLength }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 41,
+            message: "Cannot query field \"tailLength\" on type \"Pet\"."
+        )
+    }
+
+    func testInvalidWhenDefinedOnImplementorsButNotInterface() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment definedOnImplementorsButNotInterface on Pet { nickname }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 56,
+            message: "Cannot query field \"nickname\" on type \"Pet\". Did you mean \"name\"?"
+        )
+    }
+
+    /*
+    func testInvalidWhenDirectFieldSelectionOnUnion() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment directFieldSelectionOnUnion on CatOrDog { directField }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 0,
+            message: ""
+        )
+    }
+
+    func testInvalidWhenDefinedOnImplementorsQueriedOnUnion() throws {
+        let errors = try assertInvalid(
+            errorCount: 1,
+            query: "fragment definedOnImplementorsQueriedOnUnion on CatOrDog { name }"
+        )
+        try assertValidationError(
+            error: errors.first, line: 1, column: 0,
+            message: ""
+        )
+    }
+    */
+
+}
+
+extension FieldsOnCorrectTypeTests {
+    static var allTests: [(String, (FieldsOnCorrectTypeTests) -> () throws -> Void)] {
+        return [
+            ("testValidWithObjectFieldSelection", testValidWithObjectFieldSelection),
+            ("testValidWithAliasedObjectFieldSelection", testValidWithAliasedObjectFieldSelection),
+            ("testValidWithInterfaceFieldSelection", testValidWithInterfaceFieldSelection),
+            ("testValidWithAliasedInterfaceFieldSelection", testValidWithAliasedInterfaceFieldSelection),
+            ("testValidWithLyingAliasSelection", testValidWithLyingAliasSelection),
+            ("testValidWithInlineFragment", testValidWithInlineFragment),
+            ("testValidWhenMetaFieldSelectionOnUnion", testValidWhenMetaFieldSelectionOnUnion),
+            ("testValidWithIgnoresFieldsOnUnknownType", testValidWithIgnoresFieldsOnUnknownType),
+            ("testInvalidWhenTypeKnownAgain", testInvalidWhenTypeKnownAgain),
+            ("testInvalidWhenFieldNotDefined", testInvalidWhenFieldNotDefined),
+            ("testInvalidWhenDeepFieldNotDefined", testInvalidWhenDeepFieldNotDefined),
+            ("testInvalidWhenSubFieldNotDefined", testInvalidWhenSubFieldNotDefined),
+            ("testInvalidWhenFieldNotDefinedOnInlineFragment", testInvalidWhenFieldNotDefinedOnInlineFragment),
+            ("testInvalidWhenAliasedFieldTargetNotDefined", testInvalidWhenAliasedFieldTargetNotDefined),
+            ("testInvalidWhenAliasedLyingFieldTargetNotDefined", testInvalidWhenAliasedLyingFieldTargetNotDefined),
+            ("testInvalidWhenNotDefinedOnInterface", testInvalidWhenNotDefinedOnInterface),
+            ("testInvalidWhenDefinedOnImplementorsButNotInterface", testInvalidWhenDefinedOnImplementorsButNotInterface),
+            /*
+            ("testInvalidWhenDirectFieldSelectionOnUnion", testInvalidWhenDirectFieldSelectionOnUnion),
+            ("testInvalidWhenDefinedOnImplementorsQueriedOnUnion", testInvalidWhenDefinedOnImplementorsQueriedOnUnion),
+             */
+        ]
+    }
+}

--- a/Tests/GraphQLTests/ValidationTests/ValidationTests.swift
+++ b/Tests/GraphQLTests/ValidationTests/ValidationTests.swift
@@ -1,0 +1,56 @@
+@testable import GraphQL
+import XCTest
+
+class ValidationTestCase : XCTestCase {
+
+    typealias Rule = (ValidationContext) -> Visitor
+
+    var rule: Rule!
+
+    private func validate(body request: String ) throws -> [GraphQLError] {
+        return GraphQL.validate(
+            schema: ValidationExampleSchema,
+            ast: try parse(source: Source(body: request, name: "GraphQL request")),
+            rules: [rule]
+        )
+    }
+
+    func assertValid(_ query: String, file: StaticString = #file, line: UInt = #line) throws {
+        let errors = try validate(body: query)
+        XCTAssertEqual(errors.count, 0, "Expecting to pass validation without any errors", file: file, line: line)
+    }
+
+    @discardableResult func assertInvalid(
+        errorCount: Int,
+        query: String,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> [GraphQLError] {
+        let errors = try validate(body: query)
+        XCTAssertEqual(errors.count, errorCount, "Expecting to fail validation with at least 1 error", file: file, line: line)
+        return errors
+    }
+
+    func assertValidationError(
+        error: GraphQLError?,
+        line: Int,
+        column: Int,
+        path: String = "",
+        message: String,
+        testFile: StaticString = #file,
+        testLine: UInt = #line
+    ) throws {
+        guard let error = error else {
+            XCTFail("Error was not provided")
+            return
+        }
+        XCTAssertEqual(error.message, message, "Unexpected error message", file: testFile, line: testLine)
+        XCTAssertEqual(error.locations[0].line, line, "Unexpected line location", file: testFile, line: testLine)
+        XCTAssertEqual(error.locations[0].column, column, "Unexpected column location", file: testFile, line: testLine)
+        let errorPath = try error.path.map({ try $0.asMap().description }).joined(separator: " ")
+        XCTAssertEqual(errorPath, path, "Unexpected error path", file: testFile, line: testLine)
+    }
+    
+}
+
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -10,4 +10,5 @@ XCTMain([
      testCase(LexerTests.allTests),
      testCase(ParserTests.allTests),
      testCase(SchemaParserTests.allTests),
+     testCase(FieldsOnCorrectTypeTests.allTests),
 ])


### PR DESCRIPTION
Also added some additional tests for the `FieldsOnCorrectType` validator (taken from the js reference implementation).

The commented out tests are those which are in the js reference implementation but, for whatever reason, are not passing here.

The extra testing should allow for better validator validation going forward.