### PR TITLE
Add Instrumentation support

### DIFF
--- a/Sources/GraphQL/Instrumentation/DispatchQueueInstrumentationWrapper.swift
+++ b/Sources/GraphQL/Instrumentation/DispatchQueueInstrumentationWrapper.swift
@@ -1,0 +1,55 @@
+import Dispatch
+
+/// Proxies calls through to another `Instrumentation` instance via a DispatchQueue
+///
+/// Has two primary use cases:
+/// 1. Allows a non thread safe Instrumentation implementation to be used along side a multithreaded execution strategy
+/// 2. Allows slow or heavy instrumentation processing to happen outside of the current query execution
+public class DispatchQueueInstrumentationWrapper: Instrumentation {
+
+    let instrumentation:Instrumentation
+    let dispatchQueue: DispatchQueue
+    let dispatchGroup: DispatchGroup?
+
+    public init(_ instrumentation: Instrumentation, label: String = "GraphQL instrumentation wrapper", qos: DispatchQoS = .utility, attributes: DispatchQueue.Attributes = [], dispatchGroup: DispatchGroup? = nil ) {
+        self.instrumentation = instrumentation
+        self.dispatchQueue = DispatchQueue(label: label, qos: qos, attributes: attributes)
+        self.dispatchGroup = dispatchGroup
+    }
+
+    public init(_ instrumentation: Instrumentation, dispatchQueue: DispatchQueue, dispatchGroup: DispatchGroup? = nil ) {
+        self.instrumentation = instrumentation
+        self.dispatchQueue = dispatchQueue
+        self.dispatchGroup = dispatchGroup
+    }
+
+    public var now: DispatchTime {
+        return instrumentation.now
+    }
+
+    public func queryParsing(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Source, result: ResultOrError<Document, GraphQLError>) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.queryParsing(processId: processId, threadId: threadId, started: started, finished: finished, source: source, result: result)
+        }
+    }
+
+    public func queryValidation(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, errors: [GraphQLError]) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.queryValidation(processId: processId, threadId: threadId, started: started, finished: finished, schema: schema, document: document, errors: errors)
+        }
+    }
+
+    public func operationExecution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, rootValue: Any, contextValue: Any, variableValues: [String : Map], operation: OperationDefinition?, errors: [GraphQLError], result: Map) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.operationExecution(processId: processId, threadId: threadId, started: started, finished: finished, schema: schema, document: document, rootValue: rootValue, contextValue: contextValue, variableValues: variableValues, operation: operation, errors: errors, result: result)
+        }
+    }
+
+    public func fieldResolution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Any, args: Map, context: Any, info: GraphQLResolveInfo, result: ResultOrError<Any?, Error>) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.fieldResolution(processId: processId, threadId: threadId, started: started, finished: finished, source: source, args: args, context: context, info: info, result: result)
+        }
+    }
+
+}
+

--- a/Sources/GraphQL/Instrumentation/Instrumentation.swift
+++ b/Sources/GraphQL/Instrumentation/Instrumentation.swift
@@ -1,0 +1,85 @@
+import Dispatch
+
+/// Provides the capability to instrument the execution steps of a GraphQL query.
+///
+/// A working implementation of `now` is also provided by default.
+public protocol Instrumentation {
+
+    var now: DispatchTime { get }
+
+    func queryParsing(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        source: Source,
+        result: ResultOrError<Document, GraphQLError>
+    )
+
+    func queryValidation(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        schema: GraphQLSchema,
+        document: Document,
+        errors: [GraphQLError]
+    )
+
+    func operationExecution(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        schema: GraphQLSchema,
+        document: Document,
+        rootValue: Any,
+        contextValue: Any,
+        variableValues: [String: Map],
+        operation: OperationDefinition?,
+        errors: [GraphQLError],
+        result: Map
+    )
+
+    func fieldResolution(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        source: Any,
+        args: Map,
+        context: Any,
+        info: GraphQLResolveInfo,
+        result: ResultOrError<Any?, Error>
+    )
+
+}
+
+extension Instrumentation {
+    public var now: DispatchTime {
+        return DispatchTime.now()
+    }
+}
+
+func threadId() -> Int {
+    return Int(pthread_mach_thread_np(pthread_self()))
+}
+
+func processId() -> Int {
+    return Int(getpid())
+}
+
+/// Does nothing
+public let NoOpInstrumentation:Instrumentation = noOpInstrumentation()
+
+struct noOpInstrumentation: Instrumentation {
+    public let now = DispatchTime(uptimeNanoseconds: 0)
+    public func queryParsing(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Source, result: ResultOrError<Document, GraphQLError>) {
+    }
+    public func queryValidation(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, errors: [GraphQLError]) {
+    }
+    public func operationExecution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, rootValue: Any, contextValue: Any, variableValues: [String : Map], operation: OperationDefinition?, errors: [GraphQLError], result: Map) {
+    }
+    public func fieldResolution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Any, args: Map, context: Any, info: GraphQLResolveInfo, result: ResultOrError<Any?, Error>) {
+    }
+}

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -2,17 +2,51 @@
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
  */
-func parse(source: String, noLocation: Bool = false) throws -> Document {
-    return try parse(source: Source(body: source), noLocation: noLocation)
+func parse(
+    instrumentation: Instrumentation = NoOpInstrumentation,
+    source: String,
+    noLocation: Bool = false
+) throws -> Document {
+    return try parse(
+        instrumentation: instrumentation,
+        source: Source(body: source),
+        noLocation: noLocation
+    )
 }
 
 /**
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
  */
-func parse(source: Source, noLocation: Bool = false) throws -> Document {
-    let lexer = createLexer(source: source, noLocation: noLocation)
-    return try parseDocument(lexer: lexer)
+func parse(
+    instrumentation: Instrumentation = NoOpInstrumentation,
+    source: Source,
+    noLocation: Bool = false
+) throws -> Document {
+    let started = instrumentation.now
+    do {
+        let lexer = createLexer(source: source, noLocation: noLocation)
+        let document = try parseDocument(lexer: lexer)
+        instrumentation.queryParsing(
+            processId: processId(),
+            threadId: threadId(),
+            started: started,
+            finished: instrumentation.now,
+            source: source,
+            result: .result(document)
+        )
+        return document
+    } catch let error as GraphQLError {
+        instrumentation.queryParsing(
+            processId: processId(),
+            threadId: threadId(),
+            started: started,
+            finished: instrumentation.now,
+            source: source,
+            result: .error(error)
+        )
+        throw error
+    }
 }
 
 /**

--- a/Sources/GraphQL/Validation/Validate.swift
+++ b/Sources/GraphQL/Validation/Validate.swift
@@ -12,13 +12,17 @@
  * GraphQLErrors, or Arrays of GraphQLErrors when invalid.
  */
 func validate(
+    instrumentation: Instrumentation = NoOpInstrumentation,
     schema: GraphQLSchema,
     ast: Document,
     rules: [(ValidationContext) -> Visitor] = []
 ) -> [GraphQLError] {
+    let started = instrumentation.now
     let typeInfo = TypeInfo(schema: schema)
     let rules = rules.isEmpty ? specifiedRules : rules
-    return visit(usingRules: rules, schema: schema, typeInfo: typeInfo, documentAST: ast)
+    let errors = visit(usingRules: rules, schema: schema, typeInfo: typeInfo, documentAST: ast)
+    instrumentation.queryValidation(processId: processId(), threadId: threadId(), started: started, finished: instrumentation.now, schema: schema, document: ast, errors: errors)
+    return errors
 }
 
 /**

--- a/Tests/GraphQLTests/InstrumentationTests/InstrumentationTests.swift
+++ b/Tests/GraphQLTests/InstrumentationTests/InstrumentationTests.swift
@@ -1,0 +1,157 @@
+import Dispatch
+import GraphQL
+import XCTest
+
+class InstrumentationTests : XCTestCase, Instrumentation {
+
+    class MyRoot {}
+    class MyCtx {}
+
+    var query = "query sayHello($name: String) { hello(name: $name) }"
+    var expectedResult: Map = [
+        "data": [
+            "hello": "bob"
+        ]
+    ]
+    var expectedThreadId = 0
+    var expectedProcessId = 0
+    var expectedRoot = MyRoot()
+    var expectedCtx = MyCtx()
+    var expectedOpVars: [String: Map] = ["name": "bob"]
+    var expectedOpName = "sayHello"
+    var queryParsingCalled = 0
+    var queryValidationCalled = 0
+    var operationExecutionCalled = 0
+    var fieldResolutionCalled = 0
+
+    let schema = try! GraphQLSchema(
+        query: GraphQLObjectType(
+            name: "RootQueryType",
+            fields: [
+                "hello": GraphQLField(
+                    type: GraphQLString,
+                    args: [
+                        "name": GraphQLArgument(type: GraphQLNonNull(GraphQLString))
+                    ],
+                    resolve: { _, args, _, _ in return try! args["name"].asString() }
+                )
+            ]
+        )
+    )
+
+    override func setUp() {
+        expectedThreadId = 0
+        expectedProcessId = 0
+        queryParsingCalled = 0
+        queryValidationCalled = 0
+        operationExecutionCalled = 0
+        fieldResolutionCalled = 0
+    }
+
+    func queryParsing(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Source, result: ResultOrError<Document, GraphQLError>) {
+        queryParsingCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertEqual(source.name, "GraphQL request")
+        switch result {
+        case .error(let e):
+            XCTFail("unexpected error \(e)")
+        case .result(let document):
+            XCTAssertEqual(document.loc!.source.name, source.name)
+        }
+        XCTAssertEqual(source.name, "GraphQL request")
+    }
+
+    func queryValidation(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, errors: [GraphQLError]) {
+        queryValidationCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertTrue(schema === self.schema)
+        XCTAssertEqual(document.loc!.source.name, "GraphQL request")
+        XCTAssertEqual(errors, [])
+    }
+
+    func operationExecution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, rootValue: Any, contextValue: Any, variableValues: [String : Map], operation: OperationDefinition?, errors: [GraphQLError], result: Map) {
+        operationExecutionCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertTrue(schema === self.schema)
+        XCTAssertEqual(document.loc?.source.name ?? "", "GraphQL request")
+        XCTAssertTrue(rootValue as! MyRoot === expectedRoot)
+        XCTAssertTrue(contextValue as! MyCtx === expectedCtx)
+        XCTAssertEqual(variableValues, expectedOpVars)
+        XCTAssertEqual(operation!.name!.value, expectedOpName)
+        XCTAssertEqual(errors, [])
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func fieldResolution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Any, args: Map, context: Any, info: GraphQLResolveInfo, result: ResultOrError<Any?, Error>) {
+        fieldResolutionCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertTrue(source as! MyRoot === expectedRoot)
+        XCTAssertEqual(args, try! expectedOpVars.asMap())
+        XCTAssertTrue(context as! MyCtx === expectedCtx)
+        switch result {
+        case .error(let e):
+            XCTFail("unexpected error \(e)")
+        case .result(let r):
+            XCTAssertEqual(r as! String, try! expectedResult["data"]["hello"].asString())
+        }
+    }
+
+    func testInstrumentationCalls() throws {
+        expectedThreadId = Int(pthread_mach_thread_np(pthread_self()))
+        expectedProcessId = Int(getpid())
+        let result = try graphql(
+            instrumentation: self,
+            schema: schema,
+            request: query,
+            rootValue: expectedRoot,
+            contextValue: expectedCtx,
+            variableValues: expectedOpVars,
+            operationName: expectedOpName
+        )
+        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(queryParsingCalled, 1)
+        XCTAssertEqual(queryValidationCalled, 1)
+        XCTAssertEqual(operationExecutionCalled, 1)
+        XCTAssertEqual(fieldResolutionCalled, 1)
+    }
+
+    func testDispatchQueueInstrumentationWrapper() throws {
+        let dispatchGroup = DispatchGroup()
+        expectedThreadId = Int(pthread_mach_thread_np(pthread_self()))
+        expectedProcessId = Int(getpid())
+        let result = try graphql(
+            instrumentation: DispatchQueueInstrumentationWrapper(self, dispatchGroup: dispatchGroup),
+            schema: schema,
+            request: query,
+            rootValue: expectedRoot,
+            contextValue: expectedCtx,
+            variableValues: expectedOpVars,
+            operationName: expectedOpName
+        )
+        dispatchGroup.wait()
+        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(queryParsingCalled, 1)
+        XCTAssertEqual(queryValidationCalled, 1)
+        XCTAssertEqual(operationExecutionCalled, 1)
+        XCTAssertEqual(fieldResolutionCalled, 1)
+    }
+
+}
+
+extension InstrumentationTests {
+    static var allTests: [(String, (InstrumentationTests) -> () throws -> Void)] {
+        return [
+            ("testInstrumentationCalls", testInstrumentationCalls),
+            ("testDispatchQueueInstrumentationWrapper", testDispatchQueueInstrumentationWrapper),
+        ]
+    }
+}
+

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -12,4 +12,5 @@ XCTMain([
      testCase(SchemaParserTests.allTests),
      testCase(FieldExecutionStrategyTests.allTests),
      testCase(FieldsOnCorrectTypeTests.allTests),
+     testCase(InstrumentationTests.allTests),
 ])


### PR DESCRIPTION
My current thinking is that having the `Instrumentation` protocol be a number of functions that accept `started` and `finished` arguments make implementing concrete instrumentations a lot simpler then if we had an protocol that made separate calls to `beginXxx` and `finishXxx` style functions. Especially if you have many queries running concurrently or are using a concurrent field execution strategy.

Hopefully i've hooked into all of the correct places to ensure that both success and errors are reported to any instrumentation. 

For field resolution i've kept the instrumentation quite tight to include just the call to `resolveOrError` as this allows you to get better idea of how long your field resolution functions without any of the graphql runtime overhead (while you will see the overhead in the started, finished numbers for operation Execution).