### PR TITLE
Introduce persisted queries

### DIFF
--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -54,3 +54,55 @@ public func graphql(
         operationName: operationName
     )
 }
+
+/// This is the primary entry point function for fulfilling GraphQL operations
+/// by using persisted queries.
+///
+/// - parameter queryStrategy:        The field execution strategy to use for query requests
+/// - parameter mutationStrategy:     The field execution strategy to use for mutation requests
+/// - parameter subscriptionStrategy: The field execution strategy to use for subscription requests
+/// - parameter instrumentation:      The instrumentation implementation to call during the parsing, validating, execution, and field resolution stages.
+/// - parameter queryRetrieval:       The PersistedQueryRetrieval instance to use for looking up queries
+/// - parameter queryId:              The id of the query to execute
+/// - parameter rootValue:            The value provided as the first argument to resolver functions on the top level type (e.g. the query object type).
+/// - parameter contextValue:         A context value provided to all resolver functions functions
+/// - parameter variableValues:       A mapping of variable name to runtime value to use for all variables defined in the `request`.
+/// - parameter operationName:        The name of the operation to use if `request` contains multiple possible operations. Can be omitted if `request` contains only one operation.
+///
+/// - throws: throws GraphQLError if an error occurs while parsing the `request`.
+///
+/// - returns: returns a `Map` dictionary containing the result of the query inside the key `data` and any validation or execution errors inside the key `errors`. The value of `data` might be `null` if, for example, the query is invalid. It's possible to have both `data` and `errors` if an error occurs only in a specific field. If that happens the value of that field will be `null` and there will be an error inside `errors` specifying the reason for the failure and the path of the failed field.
+public func graphql<Retrieval:PersistedQueryRetrieval>(
+    queryStrategy: QueryFieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    mutationStrategy: MutationFieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    subscriptionStrategy: SubscriptionFieldExecutionStrategy = SerialFieldExecutionStrategy(),
+    instrumentation: Instrumentation = NoOpInstrumentation,
+    queryRetrieval: Retrieval,
+    queryId: Retrieval.Id,
+    rootValue: Any = Void(),
+    contextValue: Any = Void(),
+    variableValues: [String: Map] = [:],
+    operationName: String? = nil
+) throws -> Map {
+    switch try queryRetrieval.lookup(queryId) {
+    case .unknownId(_):
+        throw GraphQLError(message: "Unknown query id")
+    case .parseError(let parseError):
+        throw parseError
+    case .validateErrors(_, let validationErrors):
+        return ["errors": try validationErrors.asMap()]
+    case .result(let schema, let documentAST):
+        return try execute(
+            queryStrategy: queryStrategy,
+            mutationStrategy: mutationStrategy,
+            subscriptionStrategy: subscriptionStrategy,
+            instrumentation: instrumentation,
+            schema: schema,
+            documentAST: documentAST,
+            rootValue: rootValue,
+            contextValue: contextValue,
+            variableValues: variableValues,
+            operationName: operationName
+        )
+    }
+}

--- a/Sources/GraphQL/Instrumentation/DispatchQueueInstrumentationWrapper.swift
+++ b/Sources/GraphQL/Instrumentation/DispatchQueueInstrumentationWrapper.swift
@@ -1,0 +1,55 @@
+import Dispatch
+
+/// Proxies calls through to another `Instrumentation` instance via a DispatchQueue
+///
+/// Has two primary use cases:
+/// 1. Allows a non thread safe Instrumentation implementation to be used along side a multithreaded execution strategy
+/// 2. Allows slow or heavy instrumentation processing to happen outside of the current query execution
+public class DispatchQueueInstrumentationWrapper: Instrumentation {
+
+    let instrumentation:Instrumentation
+    let dispatchQueue: DispatchQueue
+    let dispatchGroup: DispatchGroup?
+
+    public init(_ instrumentation: Instrumentation, label: String = "GraphQL instrumentation wrapper", qos: DispatchQoS = .utility, attributes: DispatchQueue.Attributes = [], dispatchGroup: DispatchGroup? = nil ) {
+        self.instrumentation = instrumentation
+        self.dispatchQueue = DispatchQueue(label: label, qos: qos, attributes: attributes)
+        self.dispatchGroup = dispatchGroup
+    }
+
+    public init(_ instrumentation: Instrumentation, dispatchQueue: DispatchQueue, dispatchGroup: DispatchGroup? = nil ) {
+        self.instrumentation = instrumentation
+        self.dispatchQueue = dispatchQueue
+        self.dispatchGroup = dispatchGroup
+    }
+
+    public var now: DispatchTime {
+        return instrumentation.now
+    }
+
+    public func queryParsing(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Source, result: ResultOrError<Document, GraphQLError>) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.queryParsing(processId: processId, threadId: threadId, started: started, finished: finished, source: source, result: result)
+        }
+    }
+
+    public func queryValidation(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, errors: [GraphQLError]) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.queryValidation(processId: processId, threadId: threadId, started: started, finished: finished, schema: schema, document: document, errors: errors)
+        }
+    }
+
+    public func operationExecution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, rootValue: Any, contextValue: Any, variableValues: [String : Map], operation: OperationDefinition?, errors: [GraphQLError], result: Map) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.operationExecution(processId: processId, threadId: threadId, started: started, finished: finished, schema: schema, document: document, rootValue: rootValue, contextValue: contextValue, variableValues: variableValues, operation: operation, errors: errors, result: result)
+        }
+    }
+
+    public func fieldResolution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Any, args: Map, context: Any, info: GraphQLResolveInfo, result: ResultOrError<Any?, Error>) {
+        dispatchQueue.async(group: dispatchGroup) {
+            self.instrumentation.fieldResolution(processId: processId, threadId: threadId, started: started, finished: finished, source: source, args: args, context: context, info: info, result: result)
+        }
+    }
+
+}
+

--- a/Sources/GraphQL/Instrumentation/Instrumentation.swift
+++ b/Sources/GraphQL/Instrumentation/Instrumentation.swift
@@ -1,0 +1,85 @@
+import Dispatch
+
+/// Provides the capability to instrument the execution steps of a GraphQL query.
+///
+/// A working implementation of `now` is also provided by default.
+public protocol Instrumentation {
+
+    var now: DispatchTime { get }
+
+    func queryParsing(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        source: Source,
+        result: ResultOrError<Document, GraphQLError>
+    )
+
+    func queryValidation(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        schema: GraphQLSchema,
+        document: Document,
+        errors: [GraphQLError]
+    )
+
+    func operationExecution(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        schema: GraphQLSchema,
+        document: Document,
+        rootValue: Any,
+        contextValue: Any,
+        variableValues: [String: Map],
+        operation: OperationDefinition?,
+        errors: [GraphQLError],
+        result: Map
+    )
+
+    func fieldResolution(
+        processId: Int,
+        threadId: Int,
+        started: DispatchTime,
+        finished: DispatchTime,
+        source: Any,
+        args: Map,
+        context: Any,
+        info: GraphQLResolveInfo,
+        result: ResultOrError<Any?, Error>
+    )
+
+}
+
+extension Instrumentation {
+    public var now: DispatchTime {
+        return DispatchTime.now()
+    }
+}
+
+func threadId() -> Int {
+    return Int(pthread_mach_thread_np(pthread_self()))
+}
+
+func processId() -> Int {
+    return Int(getpid())
+}
+
+/// Does nothing
+public let NoOpInstrumentation:Instrumentation = noOpInstrumentation()
+
+struct noOpInstrumentation: Instrumentation {
+    public let now = DispatchTime(uptimeNanoseconds: 0)
+    public func queryParsing(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Source, result: ResultOrError<Document, GraphQLError>) {
+    }
+    public func queryValidation(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, errors: [GraphQLError]) {
+    }
+    public func operationExecution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, rootValue: Any, contextValue: Any, variableValues: [String : Map], operation: OperationDefinition?, errors: [GraphQLError], result: Map) {
+    }
+    public func fieldResolution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Any, args: Map, context: Any, info: GraphQLResolveInfo, result: ResultOrError<Any?, Error>) {
+    }
+}

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -2,17 +2,51 @@
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
  */
-func parse(source: String, noLocation: Bool = false) throws -> Document {
-    return try parse(source: Source(body: source), noLocation: noLocation)
+func parse(
+    instrumentation: Instrumentation = NoOpInstrumentation,
+    source: String,
+    noLocation: Bool = false
+) throws -> Document {
+    return try parse(
+        instrumentation: instrumentation,
+        source: Source(body: source),
+        noLocation: noLocation
+    )
 }
 
 /**
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
  */
-func parse(source: Source, noLocation: Bool = false) throws -> Document {
-    let lexer = createLexer(source: source, noLocation: noLocation)
-    return try parseDocument(lexer: lexer)
+func parse(
+    instrumentation: Instrumentation = NoOpInstrumentation,
+    source: Source,
+    noLocation: Bool = false
+) throws -> Document {
+    let started = instrumentation.now
+    do {
+        let lexer = createLexer(source: source, noLocation: noLocation)
+        let document = try parseDocument(lexer: lexer)
+        instrumentation.queryParsing(
+            processId: processId(),
+            threadId: threadId(),
+            started: started,
+            finished: instrumentation.now,
+            source: source,
+            result: .result(document)
+        )
+        return document
+    } catch let error as GraphQLError {
+        instrumentation.queryParsing(
+            processId: processId(),
+            threadId: threadId(),
+            started: started,
+            finished: instrumentation.now,
+            source: source,
+            result: .error(error)
+        )
+        throw error
+    }
 }
 
 /**

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -18,7 +18,7 @@ func parse(
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
  */
-func parse(
+public func parse(
     instrumentation: Instrumentation = NoOpInstrumentation,
     source: Source,
     noLocation: Bool = false

--- a/Sources/GraphQL/PersistedQueries/PersistedQueries.swift
+++ b/Sources/GraphQL/PersistedQueries/PersistedQueries.swift
@@ -1,0 +1,12 @@
+
+public enum PersistedQueryRetrievalResult<T> {
+    case unknownId(T)
+    case parseError(GraphQLError)
+    case validateErrors(GraphQLSchema, [GraphQLError])
+    case result(GraphQLSchema, Document)
+}
+
+public protocol PersistedQueryRetrieval {
+    associatedtype Id
+    func lookup(_ id: Id) throws -> PersistedQueryRetrievalResult<Id>
+}

--- a/Sources/GraphQL/Validation/Validate.swift
+++ b/Sources/GraphQL/Validation/Validate.swift
@@ -1,3 +1,21 @@
+/// Implements the "Validation" section of the spec.
+///
+/// Validation runs synchronously, returning an array of encountered errors, or
+/// an empty array if no errors were encountered and the document is valid.
+///
+/// - Parameters:
+///   - instrumentation: The instrumentation implementation to call during the parsing, validating, execution, and field resolution stages.
+///   - schema:          The GraphQL type system to use when validating and executing a query.
+///   - ast:             A GraphQL document representing the requested operation.
+/// - Returns: zero or more errors
+public func validate(
+    instrumentation: Instrumentation = NoOpInstrumentation,
+    schema: GraphQLSchema,
+    ast: Document
+) -> [GraphQLError] {
+    return validate(instrumentation: instrumentation, schema: schema, ast: ast, rules: [])
+}
+
 /**
  * Implements the "Validation" section of the spec.
  *
@@ -15,7 +33,7 @@ func validate(
     instrumentation: Instrumentation = NoOpInstrumentation,
     schema: GraphQLSchema,
     ast: Document,
-    rules: [(ValidationContext) -> Visitor] = []
+    rules: [(ValidationContext) -> Visitor]
 ) -> [GraphQLError] {
     let started = instrumentation.now
     let typeInfo = TypeInfo(schema: schema)

--- a/Sources/GraphQL/Validation/Validate.swift
+++ b/Sources/GraphQL/Validation/Validate.swift
@@ -12,13 +12,17 @@
  * GraphQLErrors, or Arrays of GraphQLErrors when invalid.
  */
 func validate(
+    instrumentation: Instrumentation = NoOpInstrumentation,
     schema: GraphQLSchema,
     ast: Document,
     rules: [(ValidationContext) -> Visitor] = []
 ) -> [GraphQLError] {
+    let started = instrumentation.now
     let typeInfo = TypeInfo(schema: schema)
     let rules = rules.isEmpty ? specifiedRules : rules
-    return visit(usingRules: rules, schema: schema, typeInfo: typeInfo, documentAST: ast)
+    let errors = visit(usingRules: rules, schema: schema, typeInfo: typeInfo, documentAST: ast)
+    instrumentation.queryValidation(processId: processId(), threadId: threadId(), started: started, finished: instrumentation.now, schema: schema, document: ast, errors: errors)
+    return errors
 }
 
 /**

--- a/Tests/GraphQLTests/InstrumentationTests/InstrumentationTests.swift
+++ b/Tests/GraphQLTests/InstrumentationTests/InstrumentationTests.swift
@@ -1,0 +1,157 @@
+import Dispatch
+import GraphQL
+import XCTest
+
+class InstrumentationTests : XCTestCase, Instrumentation {
+
+    class MyRoot {}
+    class MyCtx {}
+
+    var query = "query sayHello($name: String) { hello(name: $name) }"
+    var expectedResult: Map = [
+        "data": [
+            "hello": "bob"
+        ]
+    ]
+    var expectedThreadId = 0
+    var expectedProcessId = 0
+    var expectedRoot = MyRoot()
+    var expectedCtx = MyCtx()
+    var expectedOpVars: [String: Map] = ["name": "bob"]
+    var expectedOpName = "sayHello"
+    var queryParsingCalled = 0
+    var queryValidationCalled = 0
+    var operationExecutionCalled = 0
+    var fieldResolutionCalled = 0
+
+    let schema = try! GraphQLSchema(
+        query: GraphQLObjectType(
+            name: "RootQueryType",
+            fields: [
+                "hello": GraphQLField(
+                    type: GraphQLString,
+                    args: [
+                        "name": GraphQLArgument(type: GraphQLNonNull(GraphQLString))
+                    ],
+                    resolve: { _, args, _, _ in return try! args["name"].asString() }
+                )
+            ]
+        )
+    )
+
+    override func setUp() {
+        expectedThreadId = 0
+        expectedProcessId = 0
+        queryParsingCalled = 0
+        queryValidationCalled = 0
+        operationExecutionCalled = 0
+        fieldResolutionCalled = 0
+    }
+
+    func queryParsing(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Source, result: ResultOrError<Document, GraphQLError>) {
+        queryParsingCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertEqual(source.name, "GraphQL request")
+        switch result {
+        case .error(let e):
+            XCTFail("unexpected error \(e)")
+        case .result(let document):
+            XCTAssertEqual(document.loc!.source.name, source.name)
+        }
+        XCTAssertEqual(source.name, "GraphQL request")
+    }
+
+    func queryValidation(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, errors: [GraphQLError]) {
+        queryValidationCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertTrue(schema === self.schema)
+        XCTAssertEqual(document.loc!.source.name, "GraphQL request")
+        XCTAssertEqual(errors, [])
+    }
+
+    func operationExecution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, schema: GraphQLSchema, document: Document, rootValue: Any, contextValue: Any, variableValues: [String : Map], operation: OperationDefinition?, errors: [GraphQLError], result: Map) {
+        operationExecutionCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertTrue(schema === self.schema)
+        XCTAssertEqual(document.loc?.source.name ?? "", "GraphQL request")
+        XCTAssertTrue(rootValue as! MyRoot === expectedRoot)
+        XCTAssertTrue(contextValue as! MyCtx === expectedCtx)
+        XCTAssertEqual(variableValues, expectedOpVars)
+        XCTAssertEqual(operation!.name!.value, expectedOpName)
+        XCTAssertEqual(errors, [])
+        XCTAssertEqual(result, expectedResult)
+    }
+
+    func fieldResolution(processId: Int, threadId: Int, started: DispatchTime, finished: DispatchTime, source: Any, args: Map, context: Any, info: GraphQLResolveInfo, result: ResultOrError<Any?, Error>) {
+        fieldResolutionCalled += 1
+        XCTAssertEqual(processId, expectedProcessId, "unexpected process id")
+        XCTAssertEqual(threadId, expectedThreadId, "unexpected thread id")
+        XCTAssertGreaterThan(finished, started)
+        XCTAssertTrue(source as! MyRoot === expectedRoot)
+        XCTAssertEqual(args, try! expectedOpVars.asMap())
+        XCTAssertTrue(context as! MyCtx === expectedCtx)
+        switch result {
+        case .error(let e):
+            XCTFail("unexpected error \(e)")
+        case .result(let r):
+            XCTAssertEqual(r as! String, try! expectedResult["data"]["hello"].asString())
+        }
+    }
+
+    func testInstrumentationCalls() throws {
+        expectedThreadId = Int(pthread_mach_thread_np(pthread_self()))
+        expectedProcessId = Int(getpid())
+        let result = try graphql(
+            instrumentation: self,
+            schema: schema,
+            request: query,
+            rootValue: expectedRoot,
+            contextValue: expectedCtx,
+            variableValues: expectedOpVars,
+            operationName: expectedOpName
+        )
+        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(queryParsingCalled, 1)
+        XCTAssertEqual(queryValidationCalled, 1)
+        XCTAssertEqual(operationExecutionCalled, 1)
+        XCTAssertEqual(fieldResolutionCalled, 1)
+    }
+
+    func testDispatchQueueInstrumentationWrapper() throws {
+        let dispatchGroup = DispatchGroup()
+        expectedThreadId = Int(pthread_mach_thread_np(pthread_self()))
+        expectedProcessId = Int(getpid())
+        let result = try graphql(
+            instrumentation: DispatchQueueInstrumentationWrapper(self, dispatchGroup: dispatchGroup),
+            schema: schema,
+            request: query,
+            rootValue: expectedRoot,
+            contextValue: expectedCtx,
+            variableValues: expectedOpVars,
+            operationName: expectedOpName
+        )
+        dispatchGroup.wait()
+        XCTAssertEqual(result, expectedResult)
+        XCTAssertEqual(queryParsingCalled, 1)
+        XCTAssertEqual(queryValidationCalled, 1)
+        XCTAssertEqual(operationExecutionCalled, 1)
+        XCTAssertEqual(fieldResolutionCalled, 1)
+    }
+
+}
+
+extension InstrumentationTests {
+    static var allTests: [(String, (InstrumentationTests) -> () throws -> Void)] {
+        return [
+            ("testInstrumentationCalls", testInstrumentationCalls),
+            ("testDispatchQueueInstrumentationWrapper", testDispatchQueueInstrumentationWrapper),
+        ]
+    }
+}
+

--- a/Tests/GraphQLTests/PersistedQueriesTests/PersistedQueriesTests.swift
+++ b/Tests/GraphQLTests/PersistedQueriesTests/PersistedQueriesTests.swift
@@ -1,0 +1,155 @@
+import GraphQL
+import XCTest
+
+class PersistedQueriesTests: XCTestCase {
+
+    let schema = try! GraphQLSchema(
+        query: GraphQLObjectType(
+            name: "RootQueryType",
+            fields: [
+                "hello": GraphQLField(
+                    type: GraphQLString,
+                    resolve: { _ in "world" }
+                )
+            ]
+        )
+    )
+
+    func testLookupWithUnknownId() throws {
+        let result = try lookup("unknown_id")
+        switch result {
+        case .unknownId(let id):
+            XCTAssertEqual(id, "unknown_id")
+            return
+        default:
+            XCTFail("Expected unknownId result, got \(result)")
+        }
+    }
+
+    func testLookupWithParseError() throws {
+        let result = try lookup("parse_error")
+        switch result {
+        case .parseError(let error):
+            XCTAssertEqual(String(error.message.characters.prefix(57)), "Syntax Error parse_error (1:4) Expected Name, found <EOF>")
+            XCTAssertEqual(error.locations.first?.line, 1)
+            XCTAssertEqual(error.locations.first?.column, 4)
+            return
+        default:
+            XCTFail("Expected parseError result, got \(result)")
+        }
+    }
+
+    func testLookupWithValidationErrors() throws {
+        let result = try lookup("validation_errors")
+        switch result {
+        case .validateErrors(let schema, let errors):
+            XCTAssertTrue(schema === self.schema)
+            XCTAssertEqual(errors.count, 1)
+            XCTAssertEqual(errors.first?.message, "Cannot query field \"boyhowdy\" on type \"RootQueryType\".")
+            XCTAssertEqual(errors.first?.locations.first?.line, 1)
+            XCTAssertEqual(errors.first?.locations.first?.column, 3)
+            return
+        default:
+            XCTFail("Expected validateErrors result, got \(result)")
+        }
+    }
+
+    func testLookupWithResult() throws {
+        let result = try lookup("result")
+        switch result {
+        case .result(let schema, _):
+            XCTAssertTrue(schema === self.schema)
+            return
+        default:
+            XCTFail("Expected result result, got \(result)")
+        }
+    }
+
+    func testGraphQLWithUnknownId() throws {
+        do {
+            _ = try graphql(queryRetrieval: self, queryId: "unknown_id")
+        } catch let error as GraphQLError {
+            XCTAssertEqual(error.message, "Unknown query id")
+        }
+    }
+
+    func testGraphQLWithWithParseError() throws {
+        do {
+            _ = try graphql(queryRetrieval: self, queryId: "parse_error")
+        } catch let error as GraphQLError {
+            XCTAssertEqual(String(error.message.characters.prefix(57)), "Syntax Error parse_error (1:4) Expected Name, found <EOF>")
+            XCTAssertEqual(error.locations.first?.line, 1)
+            XCTAssertEqual(error.locations.first?.column, 4)
+        }
+    }
+
+    func testGraphQLWithWithValidationErrors() throws {
+        let expected: Map = [
+            "errors": [
+                [
+                    "message": "Cannot query field \"boyhowdy\" on type \"RootQueryType\".",
+                    "locations": [["line": 1, "column": 3]]
+                ]
+            ]
+        ]
+        let result = try graphql(queryRetrieval: self, queryId: "validation_errors")
+        XCTAssertEqual(result, expected)
+    }
+
+    func testGraphQLWithWithResult() throws {
+        let expected: Map = [
+            "data": [
+                "hello": "world"
+            ]
+        ]
+        let result = try graphql(queryRetrieval: self, queryId: "result")
+        XCTAssertEqual(result, expected)
+    }
+
+}
+
+extension PersistedQueriesTests: PersistedQueryRetrieval {
+    typealias Id = String
+
+    func lookup(_ id: Id) throws -> PersistedQueryRetrievalResult<Id> {
+        let source: Source
+        switch id {
+        case "parse_error":
+            source = Source(body: "{ x", name: id)
+        case "validation_errors":
+            source = Source(body: "{ boyhowdy }", name: id)
+        case "result":
+            source = Source(body: "{ hello }", name: id)
+        default:
+            return .unknownId(id)
+        }
+        do {
+            let document = try parse(source: source)
+            let validateErrors = validate(schema: schema, ast: document)
+            if validateErrors.isEmpty {
+                return .result(schema, document)
+            }
+            return .validateErrors(schema, validateErrors)
+        } catch let error as GraphQLError {
+            return .parseError(error)
+        } catch {
+            throw error
+        }
+    }
+
+}
+
+extension PersistedQueriesTests {
+    static var allTests: [(String, (PersistedQueriesTests) -> () throws -> Void)] {
+        return [
+            ("testLookupWithUnknownId", testLookupWithUnknownId),
+            ("testLookupWithParseError", testLookupWithParseError),
+            ("testLookupWithValidationErrors", testLookupWithValidationErrors),
+            ("testLookupWithResult", testLookupWithResult),
+            ("testGraphQLWithUnknownId", testGraphQLWithUnknownId),
+            ("testGraphQLWithWithParseError", testGraphQLWithWithParseError),
+            ("testGraphQLWithWithValidationErrors", testGraphQLWithWithValidationErrors),
+            ("testGraphQLWithWithResult", testGraphQLWithWithResult),
+        ]
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -12,4 +12,5 @@ XCTMain([
      testCase(SchemaParserTests.allTests),
      testCase(FieldExecutionStrategyTests.allTests),
      testCase(FieldsOnCorrectTypeTests.allTests),
+     testCase(InstrumentationTests.allTests),
 ])

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -13,4 +13,5 @@ XCTMain([
      testCase(FieldExecutionStrategyTests.allTests),
      testCase(FieldsOnCorrectTypeTests.allTests),
      testCase(InstrumentationTests.allTests),
+     testCase(PersistedQueriesTests.allTests),
 ])


### PR DESCRIPTION
**Note:** Currently implemented on top of #20 so will include some extra noise at the moment.

Takes a different approach that what I first proposed in #12.

* Deliberately kept the responsibility for performing the parsing and validating of any persisted query to `PersistedQueryRetrieval` implementations.
* Attempts to keep the calling side similar to the existing `graphql` function.

Due to the decision to put parsing and validating queries as the responsibility of any `PersistedQueryRetrieval` implementation we have to make a version of `parse()` and `validate()` public. However this does mean that implementations are free to decide when, and if, parsing and validation happens.

This means that an implementation is free to be able to only parse and validate a persisted query once when its first requested or at application launch. Therefore removing the parsing and validation time from responses.