### PR TITLE
Fix syntax on example

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ let schema = try GraphQLSchema(
         fields: [
             "hello": GraphQLField(
                 type: GraphQLString,
-                resolve: { _ in "world" }
+                resolve: { _, _, _, _ in "world" }
             )
         ]
     )


### PR DESCRIPTION
Compile error on Swift 4 when trying the example given.

```
error: cannot convert value of type '(_) -> String' to expected argument type 'GraphQLFieldResolve?' (aka 'Optional<(Any, Map, Any, GraphQLResolveInfo) throws -> Optional<Any>>')
                resolve: { _ in "world" }
```
---
Tried on:
Apple Swift version 4.0.3 (swiftlang-900.0.74.1 clang-900.0.39.2)
Target: x86_64-apple-macosx10.9