### PR TITLE
Fix performance of readString

### DIFF
--- a/Tests/GraphQLTests/LanguageTests/LexerTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/LexerTests.swift
@@ -199,6 +199,15 @@ class LexerTests : XCTestCase {
         XCTAssertEqual(token, expected)
     }
 
+    func testLongStrings() throws {
+        measure {
+            let token = try! lexOne("\"\(String(repeating: "123456", count: 10_000))\"")
+
+            XCTAssertEqual(token.start, 0)
+            XCTAssertEqual(token.end, 60_002)
+        }
+    }
+
     func testStringErrors() throws {
         XCTAssertThrowsError(try lexOne("\""))
         // "Syntax Error GraphQL (1:2) Unterminated string"


### PR DESCRIPTION
Thank you for library!

We are using it for mutating and we can pass long strings like 60k. And it works very slow as indexing over swift strings is not constant time operation. So had to switch to indexes not to subscript from start every time

e.g. for 60k before changes 5 minutes, and after changes 0.013 sec
