### PR TITLE
Fix 'completeValueCatchingError' to handle failed futures

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/vapor/core.git",
         "state": {
           "branch": null,
-          "revision": "1794ff138bd669175a2528d27695028d7cb30471",
-          "version": "3.5.0"
+          "revision": "439d6dcd6c520451ae30d39b2ca9f2aba96c22f4",
+          "version": "3.7.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "03c541a24dd0558c942b15d8464eb75d70a921c4",
-          "version": "1.12.1"
+          "revision": "87dbd0216c47ea2e7ddb1b545271b716e03b943e",
+          "version": "1.13.1"
         }
       },
       {

--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -788,7 +788,10 @@ func completeValueCatchingError(
             path: path,
             result: result
             ).mapIfError { error -> Any? in
-                exeContext.append(error: locatedError(originalError: error, nodes: fieldASTs, path: path))
+                guard let error = error as? GraphQLError else {
+                    fatalError()
+                }
+                exeContext.append(error: error)
                 return nil
             }
 
@@ -821,8 +824,9 @@ func completeValueWithLocatedError(
             info: info,
             path: path,
             result: result
-        )
-
+        ).thenIfErrorThrowing { error -> Any? in
+            throw locatedError(originalError: error, nodes: fieldASTs, path: path)
+        }
         return completed
     } catch {
         throw locatedError(

--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -788,10 +788,7 @@ func completeValueCatchingError(
             path: path,
             result: result
             ).mapIfError { error -> Any? in
-                guard let error = error as? GraphQLError else {
-                     fatalError()
-                }
-                exeContext.append(error: error)
+                exeContext.append(error: locatedError(originalError: error, nodes: fieldASTs, path: path))
                 return nil
             }
 

--- a/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
+++ b/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
@@ -208,12 +208,18 @@ class FieldExecutionStrategyTests: XCTestCase {
             seconds: seconds
         )
     }
+    
+    private var eventLoopGroup: EventLoopGroup!
+    
+    override func setUp() {
+        eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    }
+    
+    override func tearDown() {
+        XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+    }
 
     func testSerialFieldExecutionStrategyWithSingleField() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: SerialFieldExecutionStrategy(),
@@ -226,11 +232,7 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testSerialFieldExecutionStrategyWithSingleFieldError() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
-
+        
         let result = try timing(try graphql(
             queryStrategy: SerialFieldExecutionStrategy(),
             schema: schema,
@@ -242,10 +244,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
     
     func testSerialFieldExecutionStrategyWithSingleFieldFailedFuture() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
         
         let result = try timing(try graphql(
             queryStrategy: SerialFieldExecutionStrategy(),
@@ -258,10 +256,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testSerialFieldExecutionStrategyWithMultipleFields() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: SerialFieldExecutionStrategy(),
@@ -274,10 +268,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testSerialFieldExecutionStrategyWithMultipleFieldErrors() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: SerialFieldExecutionStrategy(),
@@ -295,10 +285,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testConcurrentDispatchFieldExecutionStrategyWithSingleField() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
@@ -311,10 +297,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testConcurrentDispatchFieldExecutionStrategyWithSingleFieldError() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
@@ -327,10 +309,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testConcurrentDispatchFieldExecutionStrategyWithMultipleFields() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),
@@ -343,10 +321,6 @@ class FieldExecutionStrategyTests: XCTestCase {
     }
 
     func testConcurrentDispatchFieldExecutionStrategyWithMultipleFieldErrors() throws {
-        let eventLoopGroup = MultiThreadedEventLoopGroup(numThreads: 1)
-        defer {
-            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
-        }
 
         let result = try timing(try graphql(
             queryStrategy: ConcurrentDispatchFieldExecutionStrategy(),


### PR DESCRIPTION
The implementation of completeValueCatchingError wasn't handling failed futures correctly.
It had an expectation that any failed future should only fail with GraphQLError (and would fatalError() otherwise) rather than any Error which could then be converted to a GraphQLError.