### PR TITLE
Upgrade to swift-nio 2.0.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,21 +2,30 @@
   "object": {
     "pins": [
       {
+        "package": "CRuntime",
+        "repositoryURL": "https://github.com/wickwirew/CRuntime.git",
+        "state": {
+          "branch": null,
+          "revision": "95f911318d8c885f6fc05e971471f94adfd39405",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "Runtime",
+        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
+        "state": {
+          "branch": null,
+          "revision": "c167476b07fe8cc65fdf064076a4081c3269d14a",
+          "version": "2.1.0"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ba7970fe396e8198b84c6c1b44b38a1d4e2eb6bd",
-          "version": "1.14.1"
-        }
-      },
-      {
-        "package": "swift-nio-zlib-support",
-        "repositoryURL": "https://github.com/apple/swift-nio-zlib-support.git",
-        "state": {
-          "branch": null,
-          "revision": "37760e9a52030bb9011972c5213c3350fa9d41fd",
-          "version": "1.0.0"
+          "revision": "790827800d6af12ca6a8b1dca7a9072606fd2a1e",
+          "version": "2.7.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
         .library(name: "GraphQL", targets: ["GraphQL"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "1.14.1")),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.0.0")),
         .package(url: "https://github.com/wickwirew/Runtime.git", .upToNextMinor(from: "2.1.0"))
     ],
     targets: [

--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -273,9 +273,9 @@ func execute(
             result: nil
         )
 
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: [error]))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: [error]))
     } catch {
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: [GraphQLError(error)]))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: [GraphQLError(error)]))
     }
 
     do {
@@ -285,7 +285,7 @@ func execute(
             exeContext: buildContext,
             operation: buildContext.operation,
             rootValue: rootValue
-        ).thenThrowing { data -> GraphQLResult in
+        ).flatMapThrowing { data -> GraphQLResult in
             var dataMap: Map = [:]
             
             for (key, value) in data {
@@ -300,7 +300,7 @@ func execute(
             
 //            executeErrors = buildContext.errors
             return result
-        }.mapIfError { error -> GraphQLResult in
+        }.recover { error -> GraphQLResult in
             if let error = error as? GraphQLError {
                 return GraphQLResult(errors: [error])
             }
@@ -325,9 +325,9 @@ func execute(
             return result
         }
     } catch let error as GraphQLError {
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: [error]))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: [error]))
     } catch {
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: [GraphQLError(error)]))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: [GraphQLError(error)]))
     }
 }
 
@@ -788,7 +788,7 @@ func completeValueCatchingError(
             info: info,
             path: path,
             result: result
-        ).mapIfError { error -> Any? in
+        ).recover { error -> Any? in
             guard let error = error as? GraphQLError else {
                 fatalError()
             }
@@ -801,7 +801,7 @@ func completeValueCatchingError(
         // If `completeValueWithLocatedError` returned abruptly (threw an error),
         // log the error and return .null.
         exeContext.append(error: error)
-        return exeContext.eventLoopGroup.next().newSucceededFuture(result: nil)
+        return exeContext.eventLoopGroup.next().makeSucceededFuture(nil)
     } catch {
         fatalError()
     }
@@ -825,7 +825,7 @@ func completeValueWithLocatedError(
             info: info,
             path: path,
             result: result
-        ).thenIfErrorThrowing { error -> Any? in
+        ).flatMapErrorThrowing { error -> Any? in
             throw locatedError(originalError: error, nodes: fieldASTs, path: path)
         }
         return completed
@@ -881,7 +881,7 @@ func completeValue(
                 info: info,
                 path: path,
                 result: .success(result)
-            ).thenThrowing { value -> Any? in
+            ).flatMapThrowing { value -> Any? in
                 guard let value = value else {
                     throw GraphQLError(message: "Cannot return null for non-nullable field \(info.parentType.name).\(info.fieldName).")
                 }
@@ -893,7 +893,7 @@ func completeValue(
         return result.flatMap(to: Any?.self) { result -> Future<Any?> in
             // If result value is null-ish (nil or .null) then return .null.
             guard let result = result, let r = unwrap(result) else {
-                return exeContext.eventLoopGroup.next().newSucceededFuture(result: nil)
+                return exeContext.eventLoopGroup.next().makeSucceededFuture(nil)
             }
 
             // If field type is List, complete each item in the list with the inner type
@@ -911,7 +911,7 @@ func completeValue(
             // If field type is a leaf type, Scalar or Enum, serialize to a valid value,
             // returning .null if serialization is not possible.
             if let returnType = returnType as? GraphQLLeafType {
-                return exeContext.eventLoopGroup.next().newSucceededFuture(result: try completeLeafValue(returnType: returnType, result: r))
+                return exeContext.eventLoopGroup.next().makeSucceededFuture(try completeLeafValue(returnType: returnType, result: r))
             }
 
             // If field type is an abstract type, Interface or Union, determine the
@@ -972,7 +972,7 @@ func completeListValue(
         // No need to modify the info object containing the path,
         // since from here on it is not ever accessed by resolver funcs.
         let fieldPath = path.appending(index)
-        let futureItem = item as? Future<Any?> ?? exeContext.eventLoopGroup.next().newSucceededFuture(result: item)
+        let futureItem = item as? Future<Any?> ?? exeContext.eventLoopGroup.next().makeSucceededFuture(item)
 
         let completedItem = try completeValueCatchingError(
             exeContext: exeContext,
@@ -1161,41 +1161,41 @@ func defaultResolve(
     info: GraphQLResolveInfo
 ) -> Future<Any?> {
     guard let source = unwrap(source) else {
-        return eventLoopGroup.next().newSucceededFuture(result: nil)
+        return eventLoopGroup.next().makeSucceededFuture(nil)
     }
     
     if let subscriptable = source as? KeySubscriptable {
         let value = subscriptable[info.fieldName]
-        return eventLoopGroup.next().newSucceededFuture(result: value)
+        return eventLoopGroup.next().makeSucceededFuture(value)
     }
 
     guard let encodable = source as? Encodable else {
-        return eventLoopGroup.next().newSucceededFuture(result: nil)
+        return eventLoopGroup.next().makeSucceededFuture(nil)
     }
     
     guard
         let typeInfo = try? typeInfo(of: type(of: encodable)),
         let property = try? typeInfo.property(named: info.fieldName)
     else {
-        return eventLoopGroup.next().newSucceededFuture(result: nil)
+        return eventLoopGroup.next().makeSucceededFuture(nil)
     }
     
     guard let value = try? property.get(from: encodable) else {
-        return eventLoopGroup.next().newSucceededFuture(result: nil)
+        return eventLoopGroup.next().makeSucceededFuture(nil)
     }
     
-    return eventLoopGroup.next().newSucceededFuture(result: value)
+    return eventLoopGroup.next().makeSucceededFuture(value)
     
 //    guard let any = try? AnyEncoder().encode(AnyEncodable(encodable)) else {
-//        return eventLoopGroup.next().newSucceededFuture(result: nil)
+//        return eventLoopGroup.next().makeSucceededFuture(nil)
 //    }
 //
 //    guard let dictionary = any as? [String: Any] else {
-//        return eventLoopGroup.next().newSucceededFuture(result: nil)
+//        return eventLoopGroup.next().makeSucceededFuture(nil)
 //    }
 //
 //    let value = dictionary[info.fieldName]
-//    return eventLoopGroup.next().newSucceededFuture(result: value)
+//    return eventLoopGroup.next().makeSucceededFuture(value)
 }
 
 /**

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -74,7 +74,7 @@ public func graphql(
     let validationErrors = validate(instrumentation: instrumentation, schema: schema, ast: documentAST)
 
     guard validationErrors.isEmpty else {
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: validationErrors))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: validationErrors))
     }
 
     return execute(
@@ -128,7 +128,7 @@ public func graphql<Retrieval: PersistedQueryRetrieval>(
     case .parseError(let parseError):
         throw parseError
     case .validateErrors(_, let validationErrors):
-        return eventLoopGroup.next().newSucceededFuture(result: GraphQLResult(errors: validationErrors))
+        return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: validationErrors))
     case .result(let schema, let documentAST):
         return execute(
             queryStrategy: queryStrategy,

--- a/Sources/GraphQL/Type/Definition.swift
+++ b/Sources/GraphQL/Type/Definition.swift
@@ -557,7 +557,7 @@ public struct GraphQLField {
         
         self.resolve = { source, args, context, eventLoopGroup, info in
             let result = try resolve(source, args, context, info)
-            return eventLoopGroup.next().newSucceededFuture(result: result)
+            return eventLoopGroup.next().makeSucceededFuture(result)
         }
     }
 }

--- a/Sources/GraphQL/Type/Introspection.swift
+++ b/Sources/GraphQL/Type/Introspection.swift
@@ -445,7 +445,7 @@ let SchemaMetaFieldDef = GraphQLFieldDefinition(
     type: GraphQLNonNull(__Schema),
     description: "Access the current type schema of this server.",
     resolve: { _, _, _, eventLoopGroup, info in
-        return eventLoopGroup.next().newSucceededFuture(result: info.schema)
+        return eventLoopGroup.next().makeSucceededFuture(info.schema)
     }
 )
 
@@ -461,7 +461,7 @@ let TypeMetaFieldDef = GraphQLFieldDefinition(
     ],
     resolve: { _, arguments, _, eventLoopGroup, info in
         let name = arguments["name"].string!
-        return eventLoopGroup.next().newSucceededFuture(result: info.schema.getType(name: name))
+        return eventLoopGroup.next().makeSucceededFuture(info.schema.getType(name: name))
     }
 )
 
@@ -470,6 +470,6 @@ let TypeNameMetaFieldDef = GraphQLFieldDefinition(
     type: GraphQLNonNull(GraphQLString),
     description: "The name of the current Object type at runtime.",
     resolve: { _, _, _, eventLoopGroup, info in
-        eventLoopGroup.next().newSucceededFuture(result: info.parentType.name)
+        eventLoopGroup.next().makeSucceededFuture(info.parentType.name)
     }
 )

--- a/Sources/GraphQL/Utilities/NIO+Extensions.swift
+++ b/Sources/GraphQL/Utilities/NIO+Extensions.swift
@@ -12,7 +12,7 @@ public typealias Future = EventLoopFuture
 
 extension Collection {
     public func flatten<T>(on eventLoopGroup: EventLoopGroup) -> Future<[T]> where Element == Future<T> {
-        return Future.whenAll(Array(self), eventLoop: eventLoopGroup.next())
+        return Future.whenAllSucceed(Array(self), on: eventLoopGroup.next())
     }
 }
 
@@ -31,10 +31,10 @@ extension Dictionary where Value : FutureType {
         var elements: [Key: Value.Expectation] = [:]
 
         guard self.count > 0 else {
-            return eventLoopGroup.next().newSucceededFuture(result: elements)
+            return eventLoopGroup.next().makeSucceededFuture(elements)
         }
 
-        let promise: EventLoopPromise<[Key: Value.Expectation]> = eventLoopGroup.next().newPromise()
+        let promise: EventLoopPromise<[Key: Value.Expectation]> = eventLoopGroup.next().makePromise()
         elements.reserveCapacity(self.count)
 
         for (key, value) in self {
@@ -42,12 +42,12 @@ extension Dictionary where Value : FutureType {
                 elements[key] = expectation
                 
                 if elements.count == self.count {
-                    promise.succeed(result: elements)
+                    promise.succeed(elements)
                 }
             }
             
             value.whenFailure { error in
-                promise.fail(error: error)
+                promise.fail(error)
             }
         }
 
@@ -59,19 +59,19 @@ extension Future {
         to type: T.Type = T.self,
         _ callback: @escaping (Expectation) throws -> Future<T>
     ) -> Future<T> {
-        let promise = eventLoop.newPromise(of: T.self)
+        let promise = eventLoop.makePromise(of: T.self)
         
         self.whenSuccess { expectation in
             do {
                 let mapped = try callback(expectation)
-                mapped.cascade(promise: promise)
+                mapped.cascade(to: promise)
             } catch {
-                promise.fail(error: error)
+                promise.fail(error)
             }
         }
             
         self.whenFailure { error in
-            promise.fail(error: error)
+            promise.fail(error)
         }
         
         return promise.futureResult
@@ -85,6 +85,6 @@ public protocol FutureType {
 }
 
 extension Future : FutureType {
-    public typealias Expectation = T
+    public typealias Expectation = Value
     
 }

--- a/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
+++ b/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
@@ -23,7 +23,7 @@ class FieldExecutionStrategyTests: XCTestCase {
                         }
                         
                         group.wait()
-                        return eventLoopGroup.next().newSucceededFuture(result: "z")
+                        return eventLoopGroup.next().makeSucceededFuture("z")
                     }
                 ),
                 "bang": GraphQLField(
@@ -55,7 +55,7 @@ class FieldExecutionStrategyTests: XCTestCase {
                         
                         g.wait()
                         
-                        return eventLoopGroup.next().newFailedFuture(error: StrategyError.exampleError(
+                        return eventLoopGroup.next().makeFailedFuture(StrategyError.exampleError(
                             msg: "\(info.fieldName): \(info.path.elements.last!)"
                         ))
                     }


### PR DESCRIPTION
This is PR upgrades GraphQL to use swift-nio 2.
I was not able to use the package because some of my other dependencies require swift-nio 2.
The was my motivation to upgrade the package to use swift-nio 2.