### PR TITLE
Fix boolean serialization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ notifications:
 language: generic
 env:
   global:
-  - SWIFT_VERSION=5.0
+  - SWIFT_VERSION=5.1
 matrix:
   include:
     - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ matrix:
   include:
     - os: osx
       env: JOB=SwiftPM_OSX
-      osx_image: xcode10.2
+      osx_image: xcode11
     - os: linux
       env: JOB=SwiftPM_linux
-      dist: trusty
+      dist: bionic
       sudo: required
       install:
         -  travis_retry eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "CRuntime",
+        "repositoryURL": "https://github.com/wickwirew/CRuntime.git",
+        "state": {
+          "branch": null,
+          "revision": "95f911318d8c885f6fc05e971471f94adfd39405",
+          "version": "2.1.2"
+        }
+      },
+      {
+        "package": "Runtime",
+        "repositoryURL": "https://github.com/wickwirew/Runtime.git",
+        "state": {
+          "branch": null,
+          "revision": "c167476b07fe8cc65fdf064076a4081c3269d14a",
+          "version": "2.1.0"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {

--- a/Sources/GraphQL/Map/AnyCoder.swift
+++ b/Sources/GraphQL/Map/AnyCoder.swift
@@ -2048,7 +2048,7 @@ extension _AnyDecoder {
     fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }
 
-        #if DEPLOYMENT_RUNTIME_SWIFT
+        #if DEPLOYMENT_RUNTIME_SWIFT || os(Linux)
         // Bridging differences require us to split implementations here
         guard let number = __SwiftValue.store(value) as? NSNumber else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)

--- a/Sources/GraphQL/Map/Map.swift
+++ b/Sources/GraphQL/Map/Map.swift
@@ -15,14 +15,11 @@ public enum MapError : Error {
 
 public enum Map {
     case null
+    case bool(Bool)
     case number(Number)
     case string(String)
     case array([Map])
     case dictionary([String: Map])
-    
-    public static func bool(_ value: Bool) -> Map {
-        return .number(Number(value))
-    }
     
     public static func int(_ value: Int) -> Map {
         return .number(Number(value))
@@ -47,7 +44,7 @@ extension Map {
     }
     
     public init(_ bool: Bool) {
-        self.init(Number(bool))
+        self = .bool(bool)
     }
     
     public init(_ int: Int) {
@@ -211,7 +208,7 @@ extension Map {
 
 extension Map {
     public var bool: Bool? {
-        return try? (get() as Number).boolValue
+        return try? get()
     }
     
     public var int: Int? {
@@ -246,6 +243,9 @@ extension Map {
         switch self {
         case .null:
             return false
+
+        case let .bool(value):
+            return value
             
         case let .number(number):
             return number.boolValue
@@ -321,6 +321,9 @@ extension Map {
         switch self {
         case .null:
             return "null"
+
+        case let .bool(value):
+            return "\(value)"
             
         case let .number(number):
             return number.stringValue
@@ -378,6 +381,8 @@ extension Map {
         if indexPath.isEmpty {
             switch self {
             case let .number(value as T):
+                return value
+            case let .bool(value as T):
                 return value
             case let .string(value as T):
                 return value
@@ -608,6 +613,8 @@ extension Map : Codable {
         switch self {
         case .null:
             try container.encodeNil()
+        case let .bool(value):
+            try container.encode(value)
         case let .number(number):
             try container.encode(number.doubleValue)
         case let .string(string):
@@ -647,6 +654,8 @@ extension Map : Hashable {
         switch self {
         case .null:
             hasher.combine(0)
+        case let .bool(value):
+            hasher.combine(value)
         case let .number(number):
             hasher.combine(number)
         case let .string(string):
@@ -743,6 +752,8 @@ extension Map {
             switch map {
             case .null:
                 return "null"
+            case let .bool(value):
+                return value.description
             case let .number(number):
                 return number.description
             case .string(let string):

--- a/Sources/GraphQL/Map/MapCoder.swift
+++ b/Sources/GraphQL/Map/MapCoder.swift
@@ -2051,7 +2051,7 @@ extension _MapDecoder {
     fileprivate func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }
 
-        #if DEPLOYMENT_RUNTIME_SWIFT
+        #if DEPLOYMENT_RUNTIME_SWIFT || os(Linux)
         // Bridging differences require us to split implementations here
         guard let number = __SwiftValue.store(value) as? NSNumber else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)

--- a/Sources/GraphQL/Map/MapSerialization.swift
+++ b/Sources/GraphQL/Map/MapSerialization.swift
@@ -36,6 +36,8 @@ public struct MapSerialization {
         switch map {
         case .null:
             return NSNull()
+        case let .bool(value):
+            return value as NSObject
         case var .number(number):
             return number.number
         case let .string(string):

--- a/Sources/GraphQL/Type/Introspection.swift
+++ b/Sources/GraphQL/Type/Introspection.swift
@@ -229,7 +229,7 @@ let __Type: GraphQLObjectType = try! GraphQLObjectType(
                     let fieldMap = type.fields
                     var fields = Array(fieldMap.values).sorted(by: { $0.name < $1.name })
 
-                    if !arguments["includeDeprecated"].bool! {
+                    if !(arguments["includeDeprecated"].bool ?? false) {
                         fields = fields.filter({ !$0.isDeprecated })
                     }
 
@@ -240,7 +240,7 @@ let __Type: GraphQLObjectType = try! GraphQLObjectType(
                     let fieldMap = type.fields
                     var fields = Array(fieldMap.values).sorted(by: { $0.name < $1.name })
 
-                    if !arguments["includeDeprecated"].bool! {
+                    if !(arguments["includeDeprecated"].bool ?? false) {
                         fields = fields.filter({ !$0.isDeprecated })
                     }
 
@@ -285,7 +285,7 @@ let __Type: GraphQLObjectType = try! GraphQLObjectType(
 
                 var values = type.values
 
-                if !arguments["includeDeprecated"].bool! {
+                if !(arguments["includeDeprecated"].bool ?? false) {
                     values = values.filter({ !$0.isDeprecated })
                 }
 

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,7 +6,6 @@ XCTMain([
      testCase(StarWarsQueryTests.allTests),
      testCase(StarWarsIntrospectionTests.allTests),
      testCase(StarWarsValidationTests.allTests),
-     testCase(MapTests.allTests),
      testCase(LexerTests.allTests),
      testCase(ParserTests.allTests),
      testCase(SchemaParserTests.allTests),


### PR DESCRIPTION
Currently boolean are serialized as Int: `0` for `false` and `1` for `true`.
It is now serialized with `true` or `false`.

This pull request also fix Linux build. Checking `DEPLOYMENT_RUNTIME_SWIFT` was not sufficient so `os(Linux)` must be added for this specific build.