### PR TITLE
Add Blockstrings support

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -55,7 +55,6 @@ final public class Token {
         case int = "Int"
         case float = "Float"
         case string = "String"
-        case blockString = "BlockString"
         case comment = "Comment"
 
         public var description: String {

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -55,6 +55,7 @@ final public class Token {
         case int = "Int"
         case float = "Float"
         case string = "String"
+        case blockString = "BlockString"
         case comment = "Comment"
 
         public var description: String {

--- a/Sources/GraphQL/Language/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer.swift
@@ -586,14 +586,7 @@ func readRawString(source: Source, start: Int, line: Int, col: Int, prev: Token)
            body.charCode(at: body.utf8.index(after: positionIndex)) == 34 {
             blockString = true
             positionIndex = body.utf8.index(positionIndex, offsetBy: 2)
-            
-            // if the first character after the """ is a newline, then it is not included in the value
-            if let code = body.charCode(at: positionIndex),
-               (code == 0x000A || code == 0x000D) {
-                positionIndex = body.utf8.index(after: positionIndex)
-            }
-            
-            chunkStartIndex = positionIndex
+			chunkStartIndex = positionIndex
         }
     }
     
@@ -619,7 +612,7 @@ func readRawString(source: Source, start: Int, line: Int, col: Int, prev: Token)
            codeNext == 34,
            let codeNextNext = body.charCode(at: body.utf8.index(after: body.utf8.index(after: positionIndex))),
            codeNextNext == 34 {
-            positionIndex = body.utf8.index(after: body.utf8.index(after: positionIndex))   // so we clean up quotes on exit
+            positionIndex = body.utf8.index(after: body.utf8.index(after: positionIndex))  // position after quotes
             break
         }
 
@@ -749,11 +742,12 @@ func readRawString(source: Source, start: Int, line: Int, col: Int, prev: Token)
  */
 
 func blockStringValue(rawValue: String) -> String {
-    var commonIndent: Int = 0
-    var lines = rawValue.utf8.split { (code) -> Bool in
+    var lines = rawValue.utf8.split(omittingEmptySubsequences: false) { (code) -> Bool in
         return code == 0x000A || code == 0x000D
     }
-    
+
+    var commonIndent: Int = 0
+
     for idx in lines.indices {
         let line = lines[idx]
         if idx == lines.startIndex { continue }
@@ -809,7 +803,7 @@ func blockStringValue(rawValue: String) -> String {
             result.append(contentsOf: Substring(lines[idx]))
         }
     }
-    
+
     return String(result)
 }
 

--- a/Sources/GraphQL/Language/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer.swift
@@ -748,19 +748,13 @@ func readRawString(source: Source, start: Int, line: Int, col: Int, prev: Token)
  */
 
 func blockStringValue(rawValue: String) -> String {
-    
-    print("inputString: \n>>>\(rawValue)<<<\n")     // debug
-    
     var commonIndent: Int = 0
     var lines = rawValue.utf8.split { (code) -> Bool in
         return code == 0x000A || code == 0x000D
     }
     
-    for line in lines { print(String(line)) }       // debug
-    
     for idx in lines.indices {
         let line = lines[idx]
-        // we already drop this before we get here..
         if idx == lines.startIndex { continue }
         if let indentIndex = line.firstIndex(where: { $0 != 0x0009 && $0 != 0x0020 }) {
             let indent = line.distance(from: line.startIndex, to: indentIndex)
@@ -769,25 +763,17 @@ func blockStringValue(rawValue: String) -> String {
             }
         }
     }
-
-    print("\ncommonIndent: \(commonIndent)\n")      // debug
     
     var newLines: [String.UTF8View.SubSequence] = []
     if commonIndent != 0 {
         for idx in lines.indices {
             let line = lines[idx]
-            // pretty sure they are dropping thinking about """\n which we already drop
             if idx == lines.startIndex {
                 newLines.append(line)
                 continue
             }
             newLines.append(line.dropFirst(commonIndent))
         }
-        
-        for line in lines { print(String(line)) }       // debug
-        print()
-        for line in newLines { print(String(line)) }    // debug
-        
         lines = newLines
         newLines.removeAll()
     }
@@ -800,14 +786,9 @@ func blockStringValue(rawValue: String) -> String {
         }
         newLines.append(line)
     }
-    
-    for line in newLines { print(String(line)) }   // debug
-    
     lines = newLines
+
     newLines.removeAll()
-    print()
-    for line in lines { print(String(line)) }     // debug
-    
     for idx in lines.indices.reversed() {
         let line = lines[idx]
         if newLines.count == 0,
@@ -816,16 +797,9 @@ func blockStringValue(rawValue: String) -> String {
         }
         newLines.insert(line, at: newLines.startIndex)
     }
-    
-    for line in newLines { print(String(line)) }   // debug
-    
     lines = newLines
-    newLines.removeAll()
-    print()
-    for line in lines { print(String(line)) }     // debug
 
     var result: Substring = Substring()
-
     for idx in lines.indices {
         if idx == lines.startIndex {
             result.append(contentsOf: Substring(lines[idx]))
@@ -834,8 +808,6 @@ func blockStringValue(rawValue: String) -> String {
             result.append(contentsOf: Substring(lines[idx]))
         }
     }
-    
-    print( "\n>>>\(result)<<<\n" )                 // debug
     
     return String(result)
 }

--- a/Tests/GraphQLTests/LanguageTests/LexerTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/LexerTests.swift
@@ -208,6 +208,75 @@ class LexerTests : XCTestCase {
         }
     }
 
+    func testMultiLineStrings() throws {
+        let token = try lexOne(#" """ Multi-line string\n With Inner "foo" \n should be Valid """ "#)
+        XCTAssertEqual(token.start, 1)
+        XCTAssert(token.kind == .string)
+        
+        let expected = Token(
+            kind: .string,
+            start: 1,
+            end: 64,
+            line: 1,
+            column: 2,
+            value: " Multi-line string\n With Inner \"foo\" \n should be Valid "
+        )
+
+        XCTAssertEqual(token, expected, "\nexpected: \n \(dump(expected))\n\ngot: \n\(dump(token))\n")
+    }
+
+    func testMultiLineStringsUnescapedReturns() throws {
+        let token = try lexOne(#"""
+                """
+                 Multi-line string
+                with Inner "foo"
+                should be valid
+                """
+                """#)
+                
+        let expected = Token(
+            kind: .string,
+            start: 0,
+            end: 59,
+            line: 1,
+            column: 1,
+            value: " Multi-line string\nwith Inner \"foo\"\nshould be valid"
+        )
+
+        XCTAssertEqual(token, expected, "expected: \n \(dump(expected))\ngot: \n\(dump(token))\n")
+    }
+
+    func fails_testMultiLineStringsUnescapedReturnsIndentationTest() throws {
+        let token = try lexOne(#"""
+                """
+                Multi-line string {
+                    with Inner "foo"
+                    should be valid indented
+                }
+                """
+                """#)
+        
+        let expected = Token(
+            kind: .string,
+            start: 0,
+            end: 71,
+            line: 1,
+            column: 1,
+            value: "Multi-line string {\nwith Inner \"foo\"\nshould be valid indented\n}"
+        )
+        
+        XCTAssertEqual(token, expected, "expected: \n \(dump(expected))\ngot: \n\(dump(token))\n")
+    }
+    
+
+    func fails_testEmptyQuote() throws {
+        XCTFail("Implement This!")
+    }
+    
+    func fails_testEmptyBlockQuote() throws {
+		XCTFail("Implement This!")
+    }
+
     func testStringErrors() throws {
         XCTAssertThrowsError(try lexOne("\""))
         // "Syntax Error GraphQL (1:2) Unterminated string"

--- a/Tests/GraphQLTests/LanguageTests/LexerTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/LexerTests.swift
@@ -209,12 +209,9 @@ class LexerTests : XCTestCase {
     }
 
     func testMultiLineStrings() throws {
-        let token = try lexOne(#" """ Multi-line string\n With Inner "foo" \n should be Valid """ "#)
-        XCTAssertEqual(token.start, 1)
-        XCTAssert(token.kind == .string)
-        
+        let token = try lexOne(#" """ Multi-line string\n With Inner "foo" \n should be Valid """ "#)        
         let expected = Token(
-            kind: .string,
+            kind: .blockString,
             start: 1,
             end: 64,
             line: 1,
@@ -235,12 +232,12 @@ class LexerTests : XCTestCase {
                 """#)
                 
         let expected = Token(
-            kind: .string,
+            kind: .blockString,
             start: 0,
             end: 59,
             line: 1,
             column: 1,
-            value: " Multi-line string\nwith Inner \"foo\"\nshould be valid"
+            value: " Multi-line string\nwith Inner \"foo\"\nshould be valid\n"
         )
 
         XCTAssertEqual(token, expected, "expected: \n \(dump(expected))\ngot: \n\(dump(token))\n")
@@ -269,13 +266,27 @@ class LexerTests : XCTestCase {
     }
     
 
-    func fails_testEmptyQuote() throws {
-        XCTFail("Implement This!")
+    func testEmptyQuote() throws {
+        let token = try lexOne(#" "" "#)
+        let expected = Token(kind: .string, start: 1, end: 3, line: 1, column: 2, value: "")
+        XCTAssertEqual(token, expected, "\n\(dump(expected))\n\(dump(token))\n")
     }
     
-    func fails_testEmptyBlockQuote() throws {
-		XCTFail("Implement This!")
+    func testEmptySimpleMultilineBlockQuote() throws {
+        let token = try lexOne(#" """""" "#)
+        let expected = Token(kind: .blockString, start: 1, end: 7, line: 1, column: 2, value: "")
+        XCTAssertEqual(token, expected, "\n\(dump(expected))\n\(dump(token))\n")
     }
+    
+    func testEmptyTrimmedCharactersMultilineBlockQuote() throws {
+        let token = try lexOne(#"""
+            """
+            """
+            """#)
+        let expected = Token(kind: .blockString, start: 0, end: 7, line: 1, column: 1, value: "")
+        XCTAssertEqual(token, expected, "\n\(dump(expected))\n\(dump(token))\n")
+    }
+
 
     func testStringErrors() throws {
         XCTAssertThrowsError(try lexOne("\""))

--- a/Tests/GraphQLTests/LanguageTests/LexerTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/LexerTests.swift
@@ -763,7 +763,7 @@ class LexerTests : XCTestCase {
                              end: 66,
                              line: 1,
                              column: 1,
-                             value: "    TopLevel {\n        indented\n        alsoIndented\n    }\n",
+                             value: "\n    TopLevel {\n        indented\n        alsoIndented\n    }\n",
                              prev: nil, next: nil)
         
         let source = Source(body: sourceStr, name: "TestSource")
@@ -777,25 +777,43 @@ class LexerTests : XCTestCase {
     }
     
     func testBlockStringIndentationAndBlankLine() throws {
-        let rawString = "\n\n\n    TopLevel {\n        indented\n        alsoIndented\n    }\n\n\n\t\t\n"   // from testReadRawString() above
-        let cleanedString = blockStringValue(rawValue: rawString)
-        
-        XCTAssertEqual(cleanedString, "    TopLevel {\n    indented\n    alsoIndented\n}")
-    }
-    
-    func testBlockStringDoubleIndentationAndBlankLine() throws {
-        let rawString = "\n\n\n    TopLevel {\n        indented: {\n            foo: String\n        }\n        alsoIndented\n    }\n\n\n\t\t\n"   // from testReadRawString() above
-        let cleanedString = blockStringValue(rawValue: rawString)
-        
-        XCTAssertEqual(cleanedString, "    TopLevel {\n    indented: {\n        foo: String\n    }\n    alsoIndented\n}")
-    }
-
-    func testBlockStringIndentationAndBlankLineFirstLineNotIndentedWeird() throws {
-        let rawString = "\n\n\nTopLevel {\n        indented\n        alsoIndented\n    }\n\n\n\t\t\n"   // from testReadRawString() above
+        let rawString = "\n\n\n    TopLevel {\n        indented\n        alsoIndented\n    }\n\n\n\t\t\n"
         let cleanedString = blockStringValue(rawValue: rawString)
         
         XCTAssertEqual(cleanedString, "TopLevel {\n    indented\n    alsoIndented\n}")
     }
+    
+    func testBlockStringDoubleIndentationAndBlankLine() throws {
+        let rawString = "\n\n\n    TopLevel {\n        indented: {\n            foo: String\n        }\n        alsoIndented\n    }\n\n\n\t\t\n"
+        let cleanedString = blockStringValue(rawValue: rawString)
+        
+        XCTAssertEqual(cleanedString, "TopLevel {\n    indented: {\n        foo: String\n    }\n    alsoIndented\n}")
+    }
+
+    func testBlockStringIndentationAndBlankLineFirstLineNotIndentedWeird() throws {
+        let rawString = "\n\n\nTopLevel {\n        indented\n        alsoIndented\n}\n\n\n\t\t\n"
+        let cleanedString = blockStringValue(rawValue: rawString)
+        
+        XCTAssertEqual(cleanedString, "TopLevel {\n        indented\n        alsoIndented\n}")
+    }
+
+    func testBlockStringIndentationMultilineAndBlankLineFirstLineNotIndentedWeird() throws {
+        let rawString = """
+            
+            
+            TopLevel {
+                indented
+                alsoIndented
+            }
+            
+            
+            \t
+            """
+        let cleanedString = blockStringValue(rawValue: rawString)
+        
+        XCTAssertEqual(cleanedString, "TopLevel {\n    indented\n    alsoIndented\n}")
+    }
+
     
     // Lexer tests for multi-line string token parsing
     
@@ -869,6 +887,34 @@ class LexerTests : XCTestCase {
         
         XCTAssertEqual(token, expected, "expected: \n \(dump(expected))\ngot: \n\(dump(token))\n")
     }
+    
+    func testMultilineStrings_stringIndentedInStream() throws {
+        let sourceStr =
+            #"""
+                """
+                Multi-line string {
+                    with Inner "foo"
+                    should be valid indented
+                }
+                """
+            """#
+        
+        let token = try lexOne(sourceStr)
+        
+        let expected = Token(
+            kind: .string,
+            start: 4,
+            end: 103,
+            line: 1,
+            column: 5,
+            value: "Multi-line string {\n    with Inner \"foo\"\n    should be valid indented\n}"
+        )
+        
+        print(sourceStr)
+        
+        XCTAssertEqual(token, expected, "expected: \n \(dump(expected))\ngot: \n\(dump(token))\n")
+    }
+
 
     // Test empty strings & multi-line string lexer token parsing
     

--- a/Tests/GraphQLTests/LanguageTests/LexerTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/LexerTests.swift
@@ -758,7 +758,7 @@ class LexerTests : XCTestCase {
             """
             """#
         
-        let expected = Token(kind: .blockString,
+        let expected = Token(kind: .string,
                              start: 0,
                              end: 66,
                              line: 1,
@@ -767,14 +767,13 @@ class LexerTests : XCTestCase {
                              prev: nil, next: nil)
         
         let source = Source(body: sourceStr, name: "TestSource")
-        let token = try readRawString(source: source,
-                                      start: 0,
-                                      line: 1,
-                                      col: 1,
-                                      prev: Token(kind: .sof, start: 0, end: 0, line: 1, column: 1))
-
+        let (token, isBlockString) = try readRawString(source: source,
+                                                       start: 0,
+                                                       line: 1,
+                                                       col: 1,
+                                                       prev: Token(kind: .sof, start: 0, end: 0, line: 1, column: 1))
+        XCTAssert(isBlockString)
         XCTAssertEqual(token, expected, "\n\(dump(expected))\n\(dump(token))\n")
-        print(String(describing: token.value))
     }
     
     func testBlockStringIndentationAndBlankLine() throws {
@@ -803,7 +802,7 @@ class LexerTests : XCTestCase {
     func testMultiLineStrings() throws {
         let token = try lexOne(#" """ Multi-line string\n With Inner "foo" \nshould be Valid """ "#)
         let expected = Token(
-            kind: .blockString,
+            kind: .string,
             start: 1,
             end: 63,
             line: 1,
@@ -817,7 +816,7 @@ class LexerTests : XCTestCase {
     func testMultiLineStringsSingleSpaceIndent() throws {
         let token = try lexOne(#" """ Multi-line string\n With Inner "foo" \n should be Valid """ "#)
         let expected = Token(
-            kind: .blockString,
+            kind: .string,
             start: 1,
             end: 64,
             line: 1,
@@ -838,7 +837,7 @@ class LexerTests : XCTestCase {
                 """#)
                 
         let expected = Token(
-            kind: .blockString,
+            kind: .string,
             start: 0,
             end: 59,
             line: 1,
@@ -860,7 +859,7 @@ class LexerTests : XCTestCase {
                 """#)
         
         let expected = Token(
-            kind: .blockString,
+            kind: .string,
             start: 0,
             end: 79,
             line: 1,
@@ -881,7 +880,7 @@ class LexerTests : XCTestCase {
     
     func testEmptySimpleMultilineBlockQuote() throws {
         let token = try lexOne(#" """""" "#)
-        let expected = Token(kind: .blockString, start: 1, end: 7, line: 1, column: 2, value: "")
+        let expected = Token(kind: .string, start: 1, end: 7, line: 1, column: 2, value: "")
         XCTAssertEqual(token, expected, "\n\(dump(expected))\n\(dump(token))\n")
     }
     
@@ -890,7 +889,7 @@ class LexerTests : XCTestCase {
             """
             """
             """#)
-        let expected = Token(kind: .blockString, start: 0, end: 7, line: 1, column: 1, value: "")
+        let expected = Token(kind: .string, start: 0, end: 7, line: 1, column: 1, value: "")
         XCTAssertEqual(token, expected, "\n\(dump(expected))\n\(dump(token))\n")
     }
 }


### PR DESCRIPTION
This PR addresses #64 "GraphQL doesn't support 'Blockstrings' which are often used in Descriptions".

There are multiple ways to implement this support and I tried to pick one that matches the existing style of lexing/parsing.  Lots of tests are included, though I'm sure more could be thought of.

There's one piece that I just noticed is missing: support for escaped Blockstrings  `\"""`
I'm out of time for this project and don't actually need those (yet), so I'm going to punt on that for now.  Shouldn't be terribly difficult, but… ¯\_(ツ)_/¯.

I hope you find these contributions acceptable in form and substance.  Feel free to let me know if there's things you'd prefer to be done differently.

All my work has been done on macOS 10.15.6 using Xcode 12b5, so I will be interested to see if this builds on linux.

Fixes #64 
