### PR TITLE
Add support for optional Description for those objects which allow it

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -56,6 +56,7 @@ final public class Token {
         case float = "Float"
         case string = "String"
         case comment = "Comment"
+        case description = "Description"    // string in a description position
 
         public var description: String {
             return rawValue
@@ -129,6 +130,19 @@ extension Token : CustomStringConvertible {
         description += ", line: \(line), column: \(column))"
 
         return description
+    }
+}
+
+extension Token {
+    convenience init(from token: Token, as kind: Kind ) {
+        self.init(kind: kind,
+                  start: token.start,
+                  end: token.end,
+                  line: token.line,
+                  column: token.column,
+                  value: token.value,
+                  prev: token.prev,
+                  next: token.next)
     }
 }
 
@@ -1075,11 +1089,13 @@ public func == (lhs: TypeSystemDefinition, rhs: TypeSystemDefinition) -> Bool {
 public final class SchemaDefinition {
     public let kind: Kind = .schemaDefinition
     public let loc: Location?
+    public let description: String?
     public let directives: [Directive]
     public let operationTypes: [OperationTypeDefinition]
 
-    init(loc: Location? = nil, directives: [Directive], operationTypes: [OperationTypeDefinition]) {
+    init(loc: Location? = nil, description: String? = nil, directives: [Directive], operationTypes: [OperationTypeDefinition]) {
         self.loc = loc
+        self.description = description
         self.directives = directives
         self.operationTypes = operationTypes
     }
@@ -1087,8 +1103,9 @@ public final class SchemaDefinition {
 
 extension SchemaDefinition : Equatable {
     public static func == (lhs: SchemaDefinition, rhs: SchemaDefinition) -> Bool {
-        return lhs.directives == rhs.directives &&
-        lhs.operationTypes == rhs.operationTypes
+        return lhs.description == rhs.description &&
+            lhs.directives == rhs.directives &&
+            lhs.operationTypes == rhs.operationTypes
     }
 }
 
@@ -1156,11 +1173,13 @@ public func == (lhs: TypeDefinition, rhs: TypeDefinition) -> Bool {
 public final class ScalarTypeDefinition {
     public let kind: Kind = .scalarTypeDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let directives: [Directive]
 
-    init(loc: Location? = nil, name: Name, directives: [Directive] = []) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, directives: [Directive] = []) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.directives = directives
     }
@@ -1168,7 +1187,8 @@ public final class ScalarTypeDefinition {
 
 extension ScalarTypeDefinition : Equatable {
     public static func == (lhs: ScalarTypeDefinition, rhs: ScalarTypeDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.directives == rhs.directives
     }
 }
@@ -1176,13 +1196,15 @@ extension ScalarTypeDefinition : Equatable {
 public final class ObjectTypeDefinition {
     public let kind: Kind = .objectTypeDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let interfaces: [NamedType]
     public let directives: [Directive]
     public let fields: [FieldDefinition]
 
-    init(loc: Location? = nil, name: Name, interfaces: [NamedType] = [], directives: [Directive] = [], fields: [FieldDefinition] = []) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, interfaces: [NamedType] = [], directives: [Directive] = [], fields: [FieldDefinition] = []) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.interfaces = interfaces
         self.directives = directives
@@ -1192,7 +1214,8 @@ public final class ObjectTypeDefinition {
 
 extension ObjectTypeDefinition : Equatable {
     public static func == (lhs: ObjectTypeDefinition, rhs: ObjectTypeDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.interfaces == rhs.interfaces &&
             lhs.directives == rhs.directives &&
             lhs.fields == rhs.fields
@@ -1202,13 +1225,15 @@ extension ObjectTypeDefinition : Equatable {
 public final class FieldDefinition {
     public let kind: Kind = .fieldDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let arguments: [InputValueDefinition]
     public let type: Type
     public let directives: [Directive]
 
-    init(loc: Location? = nil,  name: Name, arguments: [InputValueDefinition] = [], type: Type, directives: [Directive] = []) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, arguments: [InputValueDefinition] = [], type: Type, directives: [Directive] = []) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.arguments = arguments
         self.type = type
@@ -1218,7 +1243,8 @@ public final class FieldDefinition {
 
 extension FieldDefinition : Equatable {
     public static func == (lhs: FieldDefinition, rhs: FieldDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.arguments == rhs.arguments &&
             lhs.type == rhs.type &&
             lhs.directives == rhs.directives
@@ -1228,13 +1254,15 @@ extension FieldDefinition : Equatable {
 public final class InputValueDefinition {
     public let kind: Kind = .inputValueDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let type: Type
     public let defaultValue: Value?
     public let directives: [Directive]
 
-    init(loc: Location? = nil, name: Name, type: Type, defaultValue: Value? = nil, directives: [Directive] = []) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, type: Type, defaultValue: Value? = nil, directives: [Directive] = []) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.type = type
         self.defaultValue = defaultValue
@@ -1271,6 +1299,7 @@ extension InputValueDefinition : Equatable {
 public final class InterfaceTypeDefinition {
     public let kind: Kind = .interfaceTypeDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let interfaces: [NamedType]
     public let directives: [Directive]
@@ -1278,12 +1307,14 @@ public final class InterfaceTypeDefinition {
 
     init(
         loc: Location? = nil,
+        description: String? = nil,
         name: Name,
         interfaces: [NamedType] = [],
         directives: [Directive] = [],
         fields: [FieldDefinition]
     ) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.interfaces = interfaces
         self.directives = directives
@@ -1293,7 +1324,8 @@ public final class InterfaceTypeDefinition {
 
 extension InterfaceTypeDefinition : Equatable {
     public static func == (lhs: InterfaceTypeDefinition, rhs: InterfaceTypeDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.directives == rhs.directives &&
             lhs.fields == rhs.fields
     }
@@ -1302,12 +1334,14 @@ extension InterfaceTypeDefinition : Equatable {
 public final class UnionTypeDefinition {
     public let kind: Kind = .unionTypeDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let directives: [Directive]
     public let types: [NamedType]
 
-    init(loc: Location? = nil, name: Name, directives: [Directive] = [], types: [NamedType]) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, directives: [Directive] = [], types: [NamedType]) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.directives = directives
         self.types = types
@@ -1316,7 +1350,8 @@ public final class UnionTypeDefinition {
 
 extension UnionTypeDefinition : Equatable {
     public static func == (lhs: UnionTypeDefinition, rhs: UnionTypeDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.directives == rhs.directives &&
             lhs.types == rhs.types
     }
@@ -1325,12 +1360,14 @@ extension UnionTypeDefinition : Equatable {
 public final class EnumTypeDefinition {
     public let kind: Kind = .enumTypeDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let directives: [Directive]
     public let values: [EnumValueDefinition]
 
-    init(loc: Location? = nil, name: Name, directives: [Directive] = [], values: [EnumValueDefinition]) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, directives: [Directive] = [], values: [EnumValueDefinition]) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.directives = directives
         self.values = values
@@ -1339,7 +1376,8 @@ public final class EnumTypeDefinition {
 
 extension EnumTypeDefinition : Equatable {
     public static func == (lhs: EnumTypeDefinition, rhs: EnumTypeDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.directives == rhs.directives &&
             lhs.values == rhs.values
     }
@@ -1348,11 +1386,13 @@ extension EnumTypeDefinition : Equatable {
 public final class EnumValueDefinition {
     public let kind: Kind = .enumValueDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let directives: [Directive]
 
-    init(loc: Location? = nil, name: Name, directives: [Directive] = []) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, directives: [Directive] = []) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.directives = directives
     }
@@ -1360,7 +1400,8 @@ public final class EnumValueDefinition {
 
 extension EnumValueDefinition : Equatable {
     public static func == (lhs: EnumValueDefinition, rhs: EnumValueDefinition) -> Bool {
-        return lhs.name == rhs.name &&
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
             lhs.directives == rhs.directives
     }
 }
@@ -1368,12 +1409,14 @@ extension EnumValueDefinition : Equatable {
 public final class InputObjectTypeDefinition {
     public let kind: Kind = .inputObjectTypeDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let directives: [Directive]
     public let fields: [InputValueDefinition]
 
-    init(loc: Location? = nil, name: Name, directives: [Directive] = [], fields: [InputValueDefinition]) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, directives: [Directive] = [], fields: [InputValueDefinition]) {
         self.loc = loc
+        self.description = description
         self.name = name
         self.directives = directives
         self.fields = fields
@@ -1382,9 +1425,10 @@ public final class InputObjectTypeDefinition {
 
 extension InputObjectTypeDefinition : Equatable {
     public static func == (lhs: InputObjectTypeDefinition, rhs: InputObjectTypeDefinition) -> Bool {
-        return lhs.name == rhs.name &&
-        lhs.directives == rhs.directives &&
-        lhs.fields == rhs.fields
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
+            lhs.directives == rhs.directives &&
+            lhs.fields == rhs.fields
     }
 }
 
@@ -1408,13 +1452,15 @@ extension TypeExtensionDefinition : Equatable {
 public final class DirectiveDefinition {
     public let kind: Kind = .directiveDefinition
     public let loc: Location?
+    public let description: String?
     public let name: Name
     public let arguments: [InputValueDefinition]
     public let locations: [Name]
     
-    init(loc: Location? = nil, name: Name, arguments: [InputValueDefinition] = [], locations: [Name]) {
+    init(loc: Location? = nil, description: String? = nil, name: Name, arguments: [InputValueDefinition] = [], locations: [Name]) {
         self.loc = loc
         self.name = name
+        self.description = description
         self.arguments = arguments
         self.locations = locations
     }
@@ -1422,8 +1468,9 @@ public final class DirectiveDefinition {
 
 extension DirectiveDefinition : Equatable {
     public static func == (lhs: DirectiveDefinition, rhs: DirectiveDefinition) -> Bool {
-        return lhs.name == rhs.name &&
-        lhs.arguments == rhs.arguments &&
-        lhs.locations == rhs.locations
+        return lhs.description == rhs.description &&
+            lhs.name == rhs.name &&
+            lhs.arguments == rhs.arguments &&
+            lhs.locations == rhs.locations
     }
 }

--- a/Tests/GraphQLTests/LanguageTests/ParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/ParserTests.swift
@@ -266,7 +266,7 @@ class ParserTests : XCTestCase {
         let expected: Value = ListValue(
             values: [
                 IntValue(value: "123"),
-                StringValue(value: "abc")
+                StringValue(value: "abc", block: false)
             ]
         )
 

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -435,7 +435,7 @@ class SchemaParserTests : XCTestCase {
         XCTAssert(result == expected)
     }
     
-    func fails_testTypeWitMultilinehDescription() throws {
+    func testTypeWitMultilinehDescription() throws {
         let source = #"""
             """
             The Hello type.
@@ -490,7 +490,7 @@ class SchemaParserTests : XCTestCase {
         XCTAssert(result == expected)
     }
     
-    func fails_testDirectiveMultilineDesciption() throws {
+    func testDirectiveMultilineDesciption() throws {
         let source = #"""
                 """
                 directive description
@@ -684,7 +684,7 @@ class SchemaParserTests : XCTestCase {
         XCTAssert(result == expected)
     }
 
-    func fails_testTypeFieldWithMultilineDescription() throws {
+    func testTypeFieldWithMultilineDescription() throws {
         let source = #"""
             type Hello {
                 """

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -9,7 +9,7 @@ func fieldNode(_ name: Name, _ type: Type) -> FieldDefinition {
     return FieldDefinition(name: name, type: type)
 }
 
-func fieldNodeWithDescription(_ description: String? = nil, _ name: Name, _ type: Type) -> FieldDefinition {
+func fieldNodeWithDescription(_ description: StringValue? = nil, _ name: Name, _ type: Type) -> FieldDefinition {
     return FieldDefinition(description: description, name: name, type: type)
 }
 
@@ -21,7 +21,7 @@ func enumValueNode(_ name: String) -> EnumValueDefinition {
     return EnumValueDefinition(name: nameNode(name))
 }
 
-func enumValueWithDescriptionNode(_ description: String, _ name: String) -> EnumValueDefinition {
+func enumValueWithDescriptionNode(_ description: StringValue?, _ name: String) -> EnumValueDefinition {
     return EnumValueDefinition(description: description, name: nameNode(name))
 }
 
@@ -33,7 +33,7 @@ func inputValueNode(_ name: Name, _ type: Type, _ defaultValue: Value? = nil) ->
     return InputValueDefinition(name: name, type: type, defaultValue: defaultValue)
 }
 
-func inputValueWithDescriptionNode(_ description: String,
+func inputValueWithDescriptionNode(_ description: StringValue?,
                                    _ name: Name,
                                    _ type: Type,
                                    _ defaultValue: Value? = nil) -> InputValueDefinition {
@@ -416,23 +416,19 @@ class SchemaParserTests : XCTestCase {
     func testTypeWithDescription() throws {
         let source = #""The Hello type" type Hello { world: String }"#
         
-        let expected = Document(
-            definitions: [
-                ObjectTypeDefinition(
-                    description: "The Hello type",
-                    name: nameNode("Hello"),
-                    fields: [
-                        fieldNode(
-                            nameNode("world"),
-                            typeNode("String")
-                        )
-                    ]
+        let expected = ObjectTypeDefinition(
+            description: StringValue(value: "The Hello type", block: false),
+            name: nameNode("Hello"),
+            fields: [
+                fieldNode(
+                    nameNode("world"),
+                    typeNode("String")
                 )
             ]
         )
         
         let result = try parse(source: source)
-        XCTAssert(result == expected)
+        XCTAssertEqual(result.definitions[0] as! ObjectTypeDefinition, expected, "\n\(dump(result.definitions[0]))\n\(dump(expected))\n")
     }
     
     func testTypeWitMultilinehDescription() throws {
@@ -449,7 +445,7 @@ class SchemaParserTests : XCTestCase {
         let expected = Document(
             definitions: [
                 ObjectTypeDefinition(
-                    description: "The Hello type.\nMulti-line description",
+                    description: StringValue(value:"The Hello type.\nMulti-line description", block: true),
                     name: nameNode("Hello"),
                     fields: [
                         fieldNode(
@@ -471,13 +467,13 @@ class SchemaParserTests : XCTestCase {
         let expected: Document = Document(
             definitions: [
                 DirectiveDefinition(loc: nil,
-                                    description: "directive description",
+                                    description: StringValue(value: "directive description", block: false),
                                     name:  nameNode("Test"),
                                     arguments: [
                                         inputValueNode(
                                             nameNode("a"),
                                             typeNode("String"),
-                                            StringValue(value: "hello")
+                                            StringValue(value: "hello", block: false)
                                         )
                                     ],
                                     locations: [
@@ -500,13 +496,13 @@ class SchemaParserTests : XCTestCase {
         let expected: Document = Document(
             definitions: [
                 DirectiveDefinition(loc: nil,
-                                    description: "directive description",
+                                    description: StringValue(value: "directive description", block: true),
                                     name:  nameNode("Test"),
                                     arguments: [
                                         inputValueNode(
                                             nameNode("a"),
                                             typeNode("String"),
-                                            StringValue(value: "hello")
+                                            StringValue(value: "hello", block: false)
                                         )
                                     ],
                                     locations: [
@@ -523,7 +519,7 @@ class SchemaParserTests : XCTestCase {
         let source = #""Hello Schema" schema { query: Hello } "#
         
         let expected = SchemaDefinition(
-            description: "Hello Schema",
+            description: StringValue(value: "Hello Schema", block: false),
             directives: [],
             operationTypes: [
                 OperationTypeDefinition(
@@ -542,7 +538,7 @@ class SchemaParserTests : XCTestCase {
         let expected = Document(
             definitions: [
                 ScalarTypeDefinition(
-                    description: "Hello Scaler Test",
+                    description: StringValue(value: "Hello Scaler Test", block: false),
                     name: nameNode("Hello")
                 )
             ]
@@ -558,7 +554,7 @@ class SchemaParserTests : XCTestCase {
         let expected = Document(
             definitions: [
                 InterfaceTypeDefinition(
-                    description: "Hello World Interface",
+                    description: StringValue(value: "Hello World Interface", block: false),
                     name: nameNode("Hello"),
                     fields: [
                         fieldNode(
@@ -580,7 +576,7 @@ class SchemaParserTests : XCTestCase {
         let expected = Document(
             definitions: [
                 UnionTypeDefinition(
-                    description: "Hello World Union!",
+                    description: StringValue(value: "Hello World Union!", block: false),
                     name: nameNode("Hello"),
                     types: [
                         typeNode("World"),
@@ -599,7 +595,7 @@ class SchemaParserTests : XCTestCase {
         let expected = Document(
             definitions: [
                 EnumTypeDefinition(
-                    description: "Hello World Enum...",
+                    description: StringValue(value: "Hello World Enum...", block: false),
                     name: nameNode("Hello"),
                     values: [
                         enumValueNode("WORLD"),
@@ -618,7 +614,7 @@ class SchemaParserTests : XCTestCase {
         let expected = Document(
             definitions: [
                 InputObjectTypeDefinition(
-                    description: "Hello Input Object",
+                    description: StringValue(value: "Hello Input Object", block: false),
                     name: nameNode("Hello"),
                     fields: [
                         inputValueNode(
@@ -651,8 +647,8 @@ class SchemaParserTests : XCTestCase {
                 EnumTypeDefinition(
                     name: nameNode("Hello"),
                     values: [
-                        enumValueWithDescriptionNode("world description", "WORLD"),
-                        enumValueWithDescriptionNode("Hello there", "HELLO")
+                        enumValueWithDescriptionNode(StringValue(value: "world description", block: false), "WORLD"),
+                        enumValueWithDescriptionNode(StringValue(value: "Hello there", block: false), "HELLO")
                     ]
                 )
             ]
@@ -671,7 +667,7 @@ class SchemaParserTests : XCTestCase {
                     name: nameNode("Hello"),
                     fields: [
                         fieldNodeWithDescription(
-                            "The world field.",
+                            StringValue(value: "The world field.", block: false),
                             nameNode("world"),
                             typeNode("String")
                         )
@@ -701,7 +697,7 @@ class SchemaParserTests : XCTestCase {
                     name: nameNode("Hello"),
                     fields: [
                         fieldNodeWithDescription(
-                            "The world\nfield.",
+                            StringValue(value: "The world\nfield.", block: true),
                             nameNode("world"),
                             typeNode("String")
                         )
@@ -724,7 +720,7 @@ class SchemaParserTests : XCTestCase {
                     name: nameNode("Hello"),
                     fields: [
                         inputValueWithDescriptionNode(
-                            "World field",
+                            StringValue(value: "World field", block: false),
                             nameNode("world"),
                             typeNode("String")
                         )

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -9,6 +9,10 @@ func fieldNode(_ name: Name, _ type: Type) -> FieldDefinition {
     return FieldDefinition(name: name, type: type)
 }
 
+func fieldNodeWithDescription(_ description: String? = nil, _ name: Name, _ type: Type) -> FieldDefinition {
+    return FieldDefinition(description: description, name: name, type: type)
+}
+
 func typeNode(_ name: String) -> NamedType {
     return NamedType(name: nameNode(name))
 }
@@ -17,12 +21,27 @@ func enumValueNode(_ name: String) -> EnumValueDefinition {
     return EnumValueDefinition(name: nameNode(name))
 }
 
+func enumValueWithDescriptionNode(_ description: String, _ name: String) -> EnumValueDefinition {
+    return EnumValueDefinition(description: description, name: nameNode(name))
+}
+
 func fieldNodeWithArgs(_ name: Name, _ type: Type, _ args: [InputValueDefinition]) -> FieldDefinition {
     return FieldDefinition(name: name, arguments: args, type: type)
 }
 
 func inputValueNode(_ name: Name, _ type: Type, _ defaultValue: Value? = nil) -> InputValueDefinition {
     return InputValueDefinition(name: name, type: type, defaultValue: defaultValue)
+}
+
+func inputValueWithDescriptionNode(_ description: String,
+                                   _ name: Name,
+                                   _ type: Type,
+                                   _ defaultValue: Value? = nil) -> InputValueDefinition {
+    return InputValueDefinition(description: description, name: name, type: type, defaultValue: defaultValue)
+}
+
+func namedTypeNode(_ name: String ) -> NamedType {
+    return NamedType(name: nameNode(name))
 }
 
 class SchemaParserTests : XCTestCase {
@@ -376,4 +395,314 @@ class SchemaParserTests : XCTestCase {
         let source = "input Hello { world(foo: Int): String }"
         XCTAssertThrowsError(try parse(source: source))
     }
+    
+    func testSimpleSchema() throws {
+        let source = "schema { query: Hello }"
+        let expected = SchemaDefinition(
+                directives: [],
+                                        operationTypes: [
+                                            OperationTypeDefinition(
+                                                operation: .query,
+                                                type: namedTypeNode("Hello")
+                                            )
+                                        ]
+                                    )
+        let result = try parse(source: source)
+        XCTAssert(result.definitions[0] == expected)
+    }
+
+    // Description tests
+    
+    func testTypeWithDescription() throws {
+        let source = #""The Hello type" type Hello { world: String }"#
+        
+        let expected = Document(
+            definitions: [
+                ObjectTypeDefinition(
+                    description: "The Hello type",
+                    name: nameNode("Hello"),
+                    fields: [
+                        fieldNode(
+                            nameNode("world"),
+                            typeNode("String")
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func fails_testTypeWitMultilinehDescription() throws {
+        let source = #"""
+            """
+            The Hello type.
+            Multi-line description
+            """
+            type Hello {
+                world: String
+            }
+        """#
+        
+        let expected = Document(
+            definitions: [
+                ObjectTypeDefinition(
+                    name: nameNode("Hello"),
+                    fields: [
+                        fieldNode(
+                            nameNode("world"),
+                            typeNode("String")
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testDirectiveDesciption() throws {
+        let source = #""directive description" directive @Test(a: String = "hello") on FIELD"#
+        
+        let expected: Document = Document(
+            definitions: [
+                DirectiveDefinition(loc: nil,
+                                    description: "directive description",
+                                    name:  nameNode("Test"),
+                                    arguments: [
+                                        inputValueNode(
+                                            nameNode("a"),
+                                            typeNode("String"),
+                                            StringValue(value: "hello")
+                                        )
+                                    ],
+                                    locations: [
+                                        nameNode("FIELD")
+                                    ])
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func fails_testDirectiveMultilineDesciption() throws {
+        let source = #"""
+                """
+                directive description
+                """
+                directive @Test(a: String = "hello") on FIELD
+            """#
+        let expected: Document = Document(
+            definitions: [
+                DirectiveDefinition(loc: nil,
+                                    description: "directive description",
+                                    name:  nameNode("Test"),
+                                    arguments: [
+                                        inputValueNode(
+                                            nameNode("a"),
+                                            typeNode("String"),
+                                            StringValue(value: "hello")
+                                        )
+                                    ],
+                                    locations: [
+                                        nameNode("FIELD")
+                                    ])
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testSimpleSchemaWithDescription() throws {
+        let source = #""Hello Schema" schema { query: Hello } "#
+        
+        let expected = SchemaDefinition(
+            description: "Hello Schema",
+            directives: [],
+            operationTypes: [
+                OperationTypeDefinition(
+                    operation: .query,
+                    type: namedTypeNode("Hello")
+                )
+            ]
+        )
+        let result = try parse(source: source)
+        XCTAssert(result.definitions[0] == expected)
+    }
+    
+    func testScalarWithDescription() throws {
+        let source = #""Hello Scaler Test" scalar Hello"#
+        
+        let expected = Document(
+            definitions: [
+                ScalarTypeDefinition(
+                    description: "Hello Scaler Test",
+                    name: nameNode("Hello")
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testSimpleInterfaceWithDescription() throws {
+        let source = #""Hello World Interface" interface Hello { world: String } "#
+        
+        let expected = Document(
+            definitions: [
+                InterfaceTypeDefinition(
+                    description: "Hello World Interface",
+                    name: nameNode("Hello"),
+                    fields: [
+                        fieldNode(
+                            nameNode("world"),
+                            typeNode("String")
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testSimpleUnionWithDescription() throws {
+        let source = #""Hello World Union!" union Hello = World "#
+        
+        let expected = Document(
+            definitions: [
+                UnionTypeDefinition(
+                    description: "Hello World Union!",
+                    name: nameNode("Hello"),
+                    types: [
+                        typeNode("World"),
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testSingleValueEnumDescription() throws {
+        let source = #""Hello World Enum..." enum Hello { WORLD } "#
+        
+        let expected = Document(
+            definitions: [
+                EnumTypeDefinition(
+                    description: "Hello World Enum...",
+                    name: nameNode("Hello"),
+                    values: [
+                        enumValueNode("WORLD"),
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testSimpleInputObjectWithDescription() throws {
+        let source = #""Hello Input Object" input Hello { world: String }"#
+        
+        let expected = Document(
+            definitions: [
+                InputObjectTypeDefinition(
+                    description: "Hello Input Object",
+                    name: nameNode("Hello"),
+                    fields: [
+                        inputValueNode(
+                            nameNode("world"),
+                            typeNode("String")
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    // Test Fields and values with optional descriptions
+    
+    func testSingleValueEnumWithDescription() throws {
+        let source = """
+            enum Hello {
+                "world description"
+                WORLD
+                "Hello there"
+                HELLO
+            }
+            """
+        
+        let expected = Document(
+            definitions: [
+                EnumTypeDefinition(
+                    name: nameNode("Hello"),
+                    values: [
+                        enumValueWithDescriptionNode("world description", "WORLD"),
+                        enumValueWithDescriptionNode("Hello there", "HELLO")
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testTypeFieldWithDescription() throws {
+        let source = #"type Hello { "The world field." world: String } "#
+        
+        let expected = Document(
+            definitions: [
+                ObjectTypeDefinition(
+                    name: nameNode("Hello"),
+                    fields: [
+                        fieldNodeWithDescription(
+                            "The world field.",
+                            nameNode("world"),
+                            typeNode("String")
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
+    func testSimpleInputObjectFieldWithDescription() throws {
+        let source = #"input Hello { "World field" world: String }"#
+        
+        let expected = Document(
+            definitions: [
+                InputObjectTypeDefinition(
+                    name: nameNode("Hello"),
+                    fields: [
+                        inputValueWithDescriptionNode(
+                            "World field",
+                            nameNode("world"),
+                            typeNode("String")
+                        )
+                    ]
+                )
+            ]
+        )
+        
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+    
 }


### PR DESCRIPTION
This addresses #63 "GraphQL parser does not support optional `Description`s"

This adds description support via `parseTypeSystemDefinition`:
- `SchemaDefinition`
- `ScalarTypeDefintion`
- `ObjectTypeDefinition`
- `InterfaceTypeDefinition`
- `UnionTypeDefinition`
- `EnumTypeDefinition`
- `InputObjectTypeDefinition`
- `DirectiveDefinition`

others:

- `EnumValueDefinition`
- `FieldDefinition`
- `InputValueDefinition`

This also supports multi-line Descriptions now that the Blockstring PRs #65 and #68 have been merged in, and this includes several tests for those.

All my work has been done on macOS 10.15.6 using Xcode 12b5.

Fixes #63 