### PR TITLE
Fixed asserting an object implements an interface with required field arguments

### DIFF
--- a/Sources/GraphQL/Type/Definition.swift
+++ b/Sources/GraphQL/Type/Definition.swift
@@ -693,6 +693,10 @@ public struct GraphQLArgumentDefinition {
     }
 }
 
+public func isRequiredArgument(_ arg: GraphQLArgumentDefinition) -> Bool {
+    return arg.type is GraphQLNonNull && arg.defaultValue == nil
+}
+
 extension GraphQLArgumentDefinition : Encodable {
     private enum CodingKeys : String, CodingKey {
         case name

--- a/Sources/GraphQL/Type/Schema.swift
+++ b/Sources/GraphQL/Type/Schema.swift
@@ -339,15 +339,12 @@ func assert(
         // Assert additional arguments must not be required.
         for objectArg in objectField.args {
             let argName = objectArg.name
-            if interfaceField.args.find({ $0.name == argName }) != nil {
-                guard !(objectArg.type is GraphQLNonNull) else {
-                    throw GraphQLError(
-                        message:
-                        "\(object.name).\(fieldName)(\(argName):) is of required type " +
-                        "\"\(objectArg.type)\" but is not also provided by the " +
-                        "interface \(interface.name).\(fieldName)."
-                    )
-                }
+            if interfaceField.args.find({ $0.name == argName }) == nil && isRequiredArgument(objectArg) {
+                throw GraphQLError(
+                    message:
+                    "\(object.name).\(fieldName) includes required argument (\(argName):) that is missing " +
+                    "from the Interface field \(interface.name).\(fieldName)."
+                )
             }
         }
     }

--- a/Tests/GraphQLTests/TypeTests/GraphQLArgumentDefinitionTests.swift
+++ b/Tests/GraphQLTests/TypeTests/GraphQLArgumentDefinitionTests.swift
@@ -1,0 +1,34 @@
+@testable import GraphQL
+import XCTest
+
+class GraphQLArgumentDefinitionTests: XCTestCase {
+
+    func testArgumentWithNullableTypeIsNotARequiredArgument() {
+        let argument = GraphQLArgumentDefinition(
+            name: "nullableString",
+            type: GraphQLString
+        )
+
+        XCTAssertFalse(isRequiredArgument(argument))
+    }
+
+    func testArgumentWithNonNullTypeIsNotARequiredArgumentWhenItHasADefaultValue() {
+        let argument = GraphQLArgumentDefinition(
+            name: "nonNullString",
+            type: GraphQLNonNull(GraphQLString),
+            defaultValue: .string("Some string")
+        )
+
+        XCTAssertFalse(isRequiredArgument(argument))
+    }
+
+    func testArgumentWithNonNullArgumentIsARequiredArgumentWhenItDoesNotHaveADefaultValue() {
+        let argument = GraphQLArgumentDefinition(
+            name: "nonNullString",
+            type: GraphQLNonNull(GraphQLString),
+            defaultValue: nil
+        )
+
+        XCTAssertTrue(isRequiredArgument(argument))
+    }
+}

--- a/Tests/GraphQLTests/TypeTests/GraphQLSchemaTests.swift
+++ b/Tests/GraphQLTests/TypeTests/GraphQLSchemaTests.swift
@@ -1,0 +1,154 @@
+@testable import GraphQL
+import XCTest
+
+class GraphQLSchemaTests: XCTestCase {
+
+    func testAssertObjectImplementsInterfacePassesWhenObjectFieldHasRequiredArgumentsFromInterface() throws {
+        let interface = try GraphQLInterfaceType(
+            name: "Interface",
+            fields: [
+                "fieldWithNoArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [:]
+                ),
+                "fieldWithOneArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: ["requiredArg": GraphQLArgument(type: GraphQLString)]
+                ),
+                "fieldWithMultipleArgs": GraphQLField(
+                    type: GraphQLInt,
+                    args: [
+                        "arg1": GraphQLArgument(type: GraphQLString),
+                        "arg2": GraphQLArgument(type: GraphQLNonNull(GraphQLInt)),
+                        "arg3": GraphQLArgument(type: GraphQLNonNull(GraphQLBoolean))
+                    ]
+                ),
+            ]
+        )
+
+        let object = try GraphQLObjectType(
+            name: "Object",
+            fields: [
+                "fieldWithNoArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [:]
+                ),
+                "fieldWithOneArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: ["requiredArg": GraphQLArgument(type: GraphQLString)]
+                ),
+                "fieldWithMultipleArgs": GraphQLField(
+                    type: GraphQLInt,
+                    args: [
+                        "arg1": GraphQLArgument(type: GraphQLString),
+                        "arg2": GraphQLArgument(type: GraphQLNonNull(GraphQLInt)),
+                        "arg3": GraphQLArgument(type: GraphQLNonNull(GraphQLBoolean))
+                    ]
+                ),
+            ],
+            interfaces: [interface],
+            isTypeOf: { (_, _, _) -> Bool in
+                preconditionFailure("Should not be called")
+            }
+        )
+
+        _ = try GraphQLSchema(query: object, types: [interface, object])
+    }
+
+    func testAssertObjectImplementsInterfacePassesWhenObjectFieldHasRequiredArgumentMissingInInterfaceButHasDefaultValue() throws {
+        let interface = try GraphQLInterfaceType(
+            name: "Interface",
+            fields: [
+                "fieldWithOneArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [:]
+                ),
+            ]
+        )
+
+        let object = try GraphQLObjectType(
+            name: "Object",
+            fields: [
+                "fieldWithOneArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [
+                        "addedRequiredArgWithDefaultValue": GraphQLArgument(
+                            type: GraphQLNonNull(GraphQLInt),
+                            defaultValue: .int(5)
+                        )
+                    ]
+                ),
+            ],
+            interfaces: [interface],
+            isTypeOf: { (_, _, _) -> Bool in
+                preconditionFailure("Should not be called")
+            }
+        )
+
+        _ = try GraphQLSchema(query: object, types: [interface, object])
+    }
+
+    func testAssertObjectImplementsInterfacePassesWhenObjectFieldHasNullableArgumentMissingInInterface() throws {
+        let interface = try GraphQLInterfaceType(
+            name: "Interface",
+            fields: [
+                "fieldWithOneArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [:]
+                ),
+            ]
+        )
+
+        let object = try GraphQLObjectType(
+            name: "Object",
+            fields: [
+                "fieldWithOneArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: ["addedNullableArg": GraphQLArgument(type: GraphQLInt)]
+                ),
+            ],
+            interfaces: [interface],
+            isTypeOf: { (_, _, _) -> Bool in
+                preconditionFailure("Should not be called")
+            }
+        )
+
+        _ = try GraphQLSchema(query: object, types: [interface, object])
+    }
+
+    func testAssertObjectImplementsInterfaceFailsWhenObjectFieldHasRequiredArgumentMissingInInterface() throws {
+        let interface = try GraphQLInterfaceType(
+            name: "Interface",
+            fields: [
+                "fieldWithoutArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [:]
+                ),
+            ]
+        )
+
+        let object = try GraphQLObjectType(
+            name: "Object",
+            fields: [
+                "fieldWithoutArg": GraphQLField(
+                    type: GraphQLInt,
+                    args: [
+                        "addedRequiredArg": GraphQLArgument(type: GraphQLNonNull(GraphQLInt))
+                    ]
+                ),
+            ],
+            interfaces: [interface],
+            isTypeOf: { (_, _, _) -> Bool in
+                preconditionFailure("Should not be called")
+            }
+        )
+
+        do {
+            _ = try GraphQLSchema(query: object, types: [interface, object])
+            XCTFail("Expected errors when creating schema")
+        } catch {
+            let graphQLError = try XCTUnwrap(error as? GraphQLError)
+            XCTAssertEqual(graphQLError.message, "Object.fieldWithoutArg includes required argument (addedRequiredArg:) that is missing from the Interface field Interface.fieldWithoutArg.")
+        }
+    }
+}


### PR DESCRIPTION


Updated `assert(object:implementsInterface:schema:)` to work like [canonical js](https://github.com/graphql/graphql-js/blob/7b3241329e1ff49fb647b043b80568f0cf9e1a7c/src/type/validate.js#L405) when validating that additional field arguments must not be required.

Before, the assertion:
* would fail if an object's field had a required argument, even when it matched a required argument from the interface.

Now, the assertion:
* will succeed when the object's field has required arguments matching the interface
* will succeed when the object's field has additional arguments not found in the interfaces, so long as the arguments are nullable or have default values.