### PR TITLE
Support the '&' character for types implementing multiple interfaces

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -40,6 +40,7 @@ final public class Token {
         case eof = "<EOF>"
         case bang = "!"
         case dollar = "$"
+        case amp = "&"
         case openingParenthesis = "("
         case closingParenthesis = ")"
         case spread = "..."

--- a/Sources/GraphQL/Language/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer.swift
@@ -236,6 +236,16 @@ func readToken(lexer: Lexer, prev: Token) throws -> Token {
             column: col,
             prev: prev
         )
+    // &
+    case 38:
+        return Token(
+            kind: .amp,
+            start: position,
+            end: position + 1,
+            line: line,
+            column: col,
+            prev: prev
+        )
     // (
     case 40:
         return Token(

--- a/Tests/GraphQLTests/LanguageTests/ParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/ParserTests.swift
@@ -112,10 +112,39 @@ class ParserTests : XCTestCase {
                 "Syntax Error GraphQL (1:39) Unexpected Name \"null\""
             ))
         }
+
+        XCTAssertThrowsError(try parse(source: "type WithImplementsButNoTypes implements {}")) { error in
+            guard let error = error as? GraphQLError else {
+                return XCTFail()
+            }
+
+            XCTAssert(error.message.contains(
+                "Syntax Error GraphQL (1:42) Expected Name, found {"
+            ))
+        }
+
+        XCTAssertThrowsError(try parse(source: "type WithImplementsWithTrailingAmp implements AInterface & {}")) { error in
+            guard let error = error as? GraphQLError else {
+                return XCTFail()
+            }
+
+            XCTAssert(error.message.contains(
+                "Syntax Error GraphQL (1:60) Expected Name, found {"
+            ))
+        }
     }
 
     func testVariableInlineValues() throws {
         _ = try parse(source: "{ field(complex: { a: { b: [ $var ] } }) }")
+    }
+
+    func testImplementsInterface() throws {
+        _ = try parse(source: "type Swallow implements Animal {}")
+        _ = try parse(source: "type Swallow implements Animal & Bird {}")
+        _ = try parse(source: "type Swallow implements & Animal & Bird {}")
+        _ = try parse(source: "interface Bird implements Animal {}")
+        _ = try parse(source: "interface Bird implements Animal & Lifeform {}")
+        _ = try parse(source: "interface Bird implements & Animal {}")
     }
 
 //      it('parses multi-byte characters', async () => {


### PR DESCRIPTION
Added `Token.Kind.amp`
Updated lexer.readToken to handle ampersands
Updated parseImplementsInterfaces to support interface names separated by `&`, e.g:
```graphql
type Swallow implements Bird & Animal {}
```