### PR TITLE
Added support for parsing null value literals

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -728,6 +728,7 @@ extension IntValue     : Value {}
 extension FloatValue   : Value {}
 extension StringValue  : Value {}
 extension BooleanValue : Value {}
+extension NullValue    : Value {}
 extension EnumValue    : Value {}
 extension ListValue    : Value {}
 extension ObjectValue  : Value {}
@@ -752,6 +753,10 @@ public func == (lhs: Value, rhs: Value) -> Bool {
         }
     case let l as BooleanValue:
         if let r = rhs as? BooleanValue {
+            return l == r
+        }
+    case let l as NullValue:
+        if let r = rhs as? NullValue {
             return l == r
         }
     case let l as EnumValue:
@@ -840,6 +845,21 @@ public final class BooleanValue {
 extension BooleanValue : Equatable {
     public static func == (lhs: BooleanValue, rhs: BooleanValue) -> Bool {
         return lhs.value == rhs.value
+    }
+}
+
+public final class NullValue {
+    public let kind: Kind = .nullValue
+    public let loc: Location?
+
+    init(loc: Location? = nil) {
+        self.loc = loc
+    }
+}
+
+extension NullValue : Equatable {
+    public static func == (lhs: NullValue, rhs: NullValue) -> Bool {
+        return true
     }
 }
 

--- a/Sources/GraphQL/Language/Kinds.swift
+++ b/Sources/GraphQL/Language/Kinds.swift
@@ -14,6 +14,7 @@ public enum Kind {
     case floatValue
     case stringValue
     case booleanValue
+    case nullValue
     case enumValue
     case listValue
     case objectValue

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -477,7 +477,12 @@ func parseValueLiteral(lexer: Lexer, isConst: Bool) throws -> Value {
                 loc: loc(lexer: lexer, startToken: token),
                 value: token.value == "true"
             )
-        } else if token.value != "null" {
+        } else if token.value == "null" {
+            try lexer.advance()
+            return NullValue(
+                loc: loc(lexer: lexer, startToken: token)
+            )
+        } else {
             try lexer.advance()
             return EnumValue(
                 loc: loc(lexer: lexer, startToken: token),


### PR DESCRIPTION
Null value literals can now be parsed in queries
```graphql
{ fieldWithArg(arg: null) }
```
And in type definitions
```graphql
type SomeType {
  fieldWithDefaultArg(arg: String = null): String
}
```

Added tests for parsing field arguments
Added tests for parsing directives