### PR TITLE
Adds support for reference types on Input fields

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        os: [macos-10.15, macos-latest, ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2
     - name: Set code coverage path 


### PR DESCRIPTION
This adds support for recursive inputs (inputs that reference themselves). For example, the following is now a valid input definition:

```
input BoolExp {
  and: [BoolExp]
  or: [BoolExp]
  val: Bool
}
```

This builds on the Type and Interface recursion support (via `TypeReference`), by extending that functionality to Inputs as well.

It also renames a few Input Field types to be more consistent with the equivalent Type Field types