### PR TITLE
Replace `_cfTypeID` with `CFGetTypeID`

### DIFF
--- a/Sources/GraphQL/Map/AnyCoder.swift
+++ b/Sources/GraphQL/Map/AnyCoder.swift
@@ -2055,7 +2055,7 @@ extension _AnyDecoder {
         }
 
         // TODO: Add a flag to coerce non-boolean numbers into Bools?
-        guard number._cfTypeID == CFBooleanGetTypeID() else {
+        guard CFGetTypeID(number) == CFBooleanGetTypeID() else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 

--- a/Sources/GraphQL/Map/MapCoder.swift
+++ b/Sources/GraphQL/Map/MapCoder.swift
@@ -2058,7 +2058,7 @@ extension _MapDecoder {
         }
 
         // TODO: Add a flag to coerce non-boolean numbers into Bools?
-        guard number._cfTypeID == CFBooleanGetTypeID() else {
+        guard CFGetTypeID(number) == CFBooleanGetTypeID() else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }
 


### PR DESCRIPTION
because of accessibility change in Swift Foundation

Fixes #79 