### PR TITLE
Preserves result order

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections",
+        "state": {
+          "branch": null,
+          "revision": "d45e63421d3dff834949ac69d3c37691e994bd69",
+          "version": "0.0.3"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -8,12 +8,14 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.10.1")),
+        .package(url: "https://github.com/apple/swift-collections", .upToNextMajor(from: "0.0.3")),
     ],
     targets: [
         .target(
             name: "GraphQL", 
             dependencies: [
                 .product(name: "NIO", package: "swift-nio"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ]
         ),
         .testTarget(name: "GraphQLTests", dependencies: ["GraphQL"]),

--- a/Sources/GraphQL/Map/MapCoder.swift
+++ b/Sources/GraphQL/Map/MapCoder.swift
@@ -1,14 +1,16 @@
 import CoreFoundation
 import Foundation
+import OrderedCollections
 
-/// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
+
+/// A marker protocol used to determine whether a value is a `String`-keyed `OrderedDictionary`
 /// containing `Encodable` values (in which case it should be exempt from key conversion strategies).
 ///
 fileprivate protocol _MapStringDictionaryEncodableMarker { }
 
-extension Dictionary : _MapStringDictionaryEncodableMarker where Key == String, Value: Encodable { }
+extension OrderedDictionary : _MapStringDictionaryEncodableMarker where Key == String, Value: Encodable { }
 
-/// A marker protocol used to determine whether a value is a `String`-keyed `Dictionary`
+/// A marker protocol used to determine whether a value is a `String`-keyed `OrderedDictionary`
 /// containing `Decodable` values (in which case it should be exempt from key conversion strategies).
 ///
 /// The marker protocol also provides access to the type of the `Decodable` values,
@@ -18,7 +20,7 @@ fileprivate protocol _MapStringDictionaryDecodableMarker {
     static var elementType: Decodable.Type { get }
 }
 
-extension Dictionary : _MapStringDictionaryDecodableMarker where Key == String, Value: Decodable {
+extension OrderedDictionary : _MapStringDictionaryDecodableMarker where Key == String, Value: Decodable {
     static var elementType: Decodable.Type { return Value.self }
 }
 
@@ -798,7 +800,7 @@ extension _MapEncoder {
         }
     }
 
-    fileprivate func box(_ dict: [String : Encodable]) throws -> NSObject? {
+    fileprivate func box(_ dict: OrderedDictionary<String, Encodable>) throws -> NSObject? {
         let depth = self.storage.count
         let result = self.storage.pushKeyedContainer()
         do {
@@ -845,7 +847,7 @@ extension _MapEncoder {
             // MapSerialization can consume NSDecimalNumber values.
             return NSDecimalNumber(decimal: value as! Decimal)
         } else if value is _MapStringDictionaryEncodableMarker {
-            return try box((value as Any) as! [String : Encodable])
+            return try box((value as Any) as! OrderedDictionary<String, Encodable>)
         }
         
         #else
@@ -862,7 +864,7 @@ extension _MapEncoder {
             // MapSerialization can consume NSDecimalNumber values.
             return NSDecimalNumber(decimal: value as! Decimal)
         } else if value is _MapStringDictionaryEncodableMarker {
-            return try box((value as Any) as! [String : Encodable])
+            return try box((value as Any) as! OrderedDictionary<String, Encodable>)
         }
         #endif
         
@@ -2405,11 +2407,11 @@ extension _MapDecoder {
             return Decimal(doubleValue)
         }
     }
-
+    
     fileprivate func unbox<T>(_ value: Any, as type: _MapStringDictionaryDecodableMarker.Type) throws -> T? {
         guard !(value is NSNull) else { return nil }
 
-        var result = [String : Any]()
+        var result: OrderedDictionary<String, Any> = [:]
         guard let dict = value as? NSDictionary else {
             throw DecodingError._typeMismatch(at: self.codingPath, expectation: type, reality: value)
         }

--- a/Sources/GraphQL/Subscription/Subscribe.swift
+++ b/Sources/GraphQL/Subscription/Subscribe.swift
@@ -1,4 +1,5 @@
 import NIO
+import OrderedCollections
 
 /**
  * Implements the "Subscribe" algorithm described in the GraphQL specification.
@@ -168,7 +169,7 @@ func executeSubscription(
     
     // Get the first node
     let type = try getOperationRootType(schema: context.schema, operation: context.operation)
-    var inputFields: [String:[Field]] = [:]
+    var inputFields: OrderedDictionary<String, [Field]> = [:]
     var visitedFragmentNames: [String:Bool] = [:]
     let fields = try collectFields(
         exeContext: context,

--- a/Sources/GraphQL/Utilities/NIO+Extensions.swift
+++ b/Sources/GraphQL/Utilities/NIO+Extensions.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import NIO
+import OrderedCollections
 
 public typealias Future = EventLoopFuture
 
@@ -35,6 +36,24 @@ extension Dictionary where Value : FutureType {
         // when all futures have succeeded convert tuple array back to dictionary
         return EventLoopFuture.whenAllSucceed(futures, on: eventLoopGroup.next()).map {
             .init(uniqueKeysWithValues: $0)
+        }
+    }
+}
+
+extension OrderedDictionary where Value : FutureType {
+    func flatten(on eventLoopGroup: EventLoopGroup) -> Future<OrderedDictionary<Key, Value.Expectation>> {
+        let keys = self.keys
+        // create array of futures with (key,value) tuple
+        let futures: [Future<(Key, Value.Expectation)>] = self.map { element in
+            element.value.map(file: #file, line: #line) { (key: element.key, value: $0) }
+        }
+        // when all futures have succeeded convert tuple array back to dictionary
+        return EventLoopFuture.whenAllSucceed(futures, on: eventLoopGroup.next()).map { unorderedResult in
+            var result: OrderedDictionary<Key, Value.Expectation> = [:]
+            for key in keys {
+                result[key] = unorderedResult.first(where: { $0.0 == key })!.1
+            }
+            return result
         }
     }
 }

--- a/Sources/GraphQL/Utilities/ValueFromAST.swift
+++ b/Sources/GraphQL/Utilities/ValueFromAST.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 /**
  * Produces a Map value given a GraphQL Value AST.
  *
@@ -64,7 +66,7 @@ func valueFromAST(valueAST: Value?, type: GraphQLInputType, variables: [String: 
 
         let fieldASTs = objectValue.fields.keyMap({ $0.name.value })
 
-        return try .dictionary(fields.keys.reduce([:] as [String: Map]) { obj, fieldName in
+        return try .dictionary(fields.keys.reduce([:] as OrderedDictionary<String, Map>) { obj, fieldName in
             var obj = obj
             let field = fields[fieldName]
             let fieldAST = fieldASTs[fieldName]

--- a/Tests/GraphQLTests/StarWarsTests/StarWarsQueryTests.swift
+++ b/Tests/GraphQLTests/StarWarsTests/StarWarsQueryTests.swift
@@ -661,4 +661,52 @@ class StarWarsQueryTests : XCTestCase {
         let result = try graphql(schema: schema, request: query, eventLoopGroup: eventLoopGroup).wait()
         XCTAssertEqual(result, expected)
     }
+    
+    func testFieldOrderQuery() throws {
+        let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        
+        defer {
+            XCTAssertNoThrow(try eventLoopGroup.syncShutdownGracefully())
+        }
+        
+        XCTAssertEqual(try graphql(
+            schema: starWarsSchema,
+            request: """
+                query HeroNameQuery {
+                    hero {
+                        id
+                        name
+                    }
+                }
+                """,
+            eventLoopGroup: eventLoopGroup
+        ).wait(), GraphQLResult(
+            data: [
+                "hero": [
+                    "id": "2001",
+                    "name": "R2-D2"
+                ],
+            ]
+        ))
+        
+        XCTAssertNotEqual(try graphql(
+            schema: starWarsSchema,
+            request: """
+                query HeroNameQuery {
+                    hero {
+                        id
+                        name
+                    }
+                }
+                """,
+            eventLoopGroup: eventLoopGroup
+        ).wait(), GraphQLResult(
+            data: [
+                "hero": [
+                    "name": "R2-D2",
+                    "id": "2001"
+                ],
+            ]
+        ))
+    }
 }


### PR DESCRIPTION
Fixes #60 

This was implemented by adding the Swift Collections dependency and adjusting most ordinary `Dictionary` instances to `OrderedDictionary`.

Graphiti will require a PR to be compatible, which I will submit shortly.

Thanks!!