### PR TITLE
Changing Void() default parameters to avoid a recent compiler crasher

### DIFF
--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -81,8 +81,8 @@ public func graphql(
     instrumentation: Instrumentation = NoOpInstrumentation,
     schema: GraphQLSchema,
     request: String,
-    rootValue: Any = Void(),
-    context: Any = Void(),
+    rootValue: Any = (),
+    context: Any = (),
     eventLoopGroup: EventLoopGroup,
     variableValues: [String: Map] = [:],
     operationName: String? = nil
@@ -135,8 +135,8 @@ public func graphql<Retrieval: PersistedQueryRetrieval>(
     instrumentation: Instrumentation = NoOpInstrumentation,
     queryRetrieval: Retrieval,
     queryId: Retrieval.Id,
-    rootValue: Any = Void(),
-    context: Any = Void(),
+    rootValue: Any = (),
+    context: Any = (),
     eventLoopGroup: EventLoopGroup,
     variableValues: [String: Map] = [:],
     operationName: String? = nil
@@ -198,8 +198,8 @@ public func graphqlSubscribe(
     instrumentation: Instrumentation = NoOpInstrumentation,
     schema: GraphQLSchema,
     request: String,
-    rootValue: Any = Void(),
-    context: Any = Void(),
+    rootValue: Any = (),
+    context: Any = (),
     eventLoopGroup: EventLoopGroup,
     variableValues: [String: Map] = [:],
     operationName: String? = nil


### PR DESCRIPTION
Starting with the August 28, 2021 Swift.org nightly development snapshot, there is currently a compiler crasher when building Swift code that contains a default parameter of `Void()` with debug symbols enabled. This has been reported as [SR-15181](https://bugs.swift.org/browse/SR-15181) and the Swift team is aware of it.

An easy way to work around this is to make the stylistic change from `= Void()` to `= ()` in these default parameters. That no longer triggers the compiler crasher. I've done that here, because GraphQL was the only project in our dependencies that had an example of this specific crasher.

This crasher did not make its way into the 5.5 release, and most likely will be fixed before the next stable release, so I understand if you're hesitant to make this stylistic change based on what's probably a temporary crasher. We use compiler toolchains based on Swift head in order to employ the latest experimental differentiable Swift capabilities, and rely on GraphQL within our project, so we're a bit of a special case. This crasher is preventing us from stepping up our Swift toolchains to use Swift head, however.

Again, I understand if you don't want to make this change while this crasher is being looked into. The true fix is to address it at the source in the compiler, but I'm unsure how long that will take.