### PR TITLE
Variable and argument null vs undefined

### DIFF
--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -594,7 +594,7 @@ func shouldIncludeNode(exeContext: ExecutionContext, directives: [Directive] = [
         let skip = try getArgumentValues(
             argDefs: GraphQLSkipDirective.args,
             argASTs: skipAST.arguments,
-            variableValues: exeContext.variableValues
+            variables: exeContext.variableValues
         )
 
         if skip["if"] == .bool(true) {
@@ -606,7 +606,7 @@ func shouldIncludeNode(exeContext: ExecutionContext, directives: [Directive] = [
         let include = try getArgumentValues(
             argDefs: GraphQLIncludeDirective.args,
             argASTs: includeAST.arguments,
-            variableValues: exeContext.variableValues
+            variables: exeContext.variableValues
         )
 
         if include["if"] == .bool(false) {
@@ -685,7 +685,7 @@ public func resolveField(
     let args = try getArgumentValues(
         argDefs: fieldDef.args,
         argASTs: fieldAST.arguments,
-        variableValues: exeContext.variableValues
+        variables: exeContext.variableValues
     )
 
     // The resolve func's optional third argument is a context value that

--- a/Sources/GraphQL/Execution/Values.swift
+++ b/Sources/GraphQL/Execution/Values.swift
@@ -7,18 +7,25 @@ import OrderedCollections
  * parsed to match the variable definitions, a GraphQLError will be thrown.
  */
 func getVariableValues(schema: GraphQLSchema, definitionASTs: [VariableDefinition], inputs: [String: Map]) throws -> [String: Map] {
-    return try definitionASTs.reduce([:]) { values, defAST in
-        var valuesCopy = values
+    
+    var vars = [String: Map]()
+    for defAST in definitionASTs {
         let varName = defAST.variable.name.value
-
-        valuesCopy[varName] = try getVariableValue(
+        
+        let input: Map
+        if let nonNilInput = inputs[varName] {
+            input = nonNilInput
+        } else {
+            // If variable is not in inputs it is undefined
+            input = .undefined
+        }
+        vars[varName] = try getVariableValue(
             schema: schema,
             definitionAST: defAST,
-            input: inputs[varName] ?? .null
+            input: input
         )
-
-        return valuesCopy
     }
+    return vars
 }
 
 

--- a/Sources/GraphQL/Map/Map.swift
+++ b/Sources/GraphQL/Map/Map.swift
@@ -709,6 +709,8 @@ extension Map : Equatable {}
 
 public func == (lhs: Map, rhs: Map) -> Bool {
     switch (lhs, rhs) {
+    case (.undefined, .undefined):
+        return true
     case (.null, .null):
         return true
     case let (.bool(l), .bool(r)) where l == r:

--- a/Sources/GraphQL/Subscription/Subscribe.swift
+++ b/Sources/GraphQL/Subscription/Subscribe.swift
@@ -195,7 +195,7 @@ func executeSubscription(
 
     // Build a map of arguments from the field.arguments AST, using the
     // variables scope to fulfill any variable references.
-    let args = try getArgumentValues(argDefs: fieldDef.args, argASTs: fieldNode.arguments, variableValues: context.variableValues)
+    let args = try getArgumentValues(argDefs: fieldDef.args, argASTs: fieldNode.arguments, variables: context.variableValues)
 
     // The resolve function's optional third argument is a context value that
     // is provided to every resolve function within an execution. It is commonly

--- a/Sources/GraphQL/Utilities/ValueFromAST.swift
+++ b/Sources/GraphQL/Utilities/ValueFromAST.swift
@@ -72,7 +72,7 @@ func valueFromAST(valueAST: Value, type: GraphQLInputType, variables: [String: M
 
     if let objectType = type as? GraphQLInputObjectType {
         guard let objectValue = valueAST as? ObjectValue else {
-            throw GraphQLError(message: "Must be object type")
+            throw GraphQLError(message: "Input object must be object type")
         }
 
         let fields = objectType.fields
@@ -102,5 +102,5 @@ func valueFromAST(valueAST: Value, type: GraphQLInputType, variables: [String: M
         return try leafType.parseLiteral(valueAST: valueAST)
     }
     
-    throw GraphQLError(message: "Must be input type")
+    throw GraphQLError(message: "Provided type is not an input type")
 }

--- a/Sources/GraphQL/Utilities/ValueFromAST.swift
+++ b/Sources/GraphQL/Utilities/ValueFromAST.swift
@@ -37,7 +37,7 @@ func valueFromAST(valueAST: Value, type: GraphQLInputType, variables: [String: M
         if let variable = variables[variableName] {
             return variable
         } else {
-            return .null
+            return .undefined
         }
     }
 
@@ -92,6 +92,6 @@ func valueFromAST(valueAST: Value, type: GraphQLInputType, variables: [String: M
         throw GraphQLError(message: "Must be leaf type")
     }
     
-    // If we've made it this far, it should be a literal
+    // If we've made it this far, it should be a scalar
     return try type.parseLiteral(valueAST: valueAST)
 }

--- a/Tests/GraphQLTests/InputTests/InputTests.swift
+++ b/Tests/GraphQLTests/InputTests/InputTests.swift
@@ -509,7 +509,7 @@ class InputTests : XCTestCase {
             try graphql(
                 schema: schema,
                 request: """
-                query echo($field1: String) {
+                query echo($field1: String! = "defaultValue1") {
                     echo (
                         field1: $field1
                     ) {
@@ -525,6 +525,25 @@ class InputTests : XCTestCase {
                     "field1": "defaultValue1"
                 ]
             ])
+        )
+        
+        // Test variable doesn't get argument default
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo (
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [:]
+            ).wait()
+            .errors.count > 0
         )
     }
     
@@ -692,7 +711,7 @@ class InputTests : XCTestCase {
             try graphql(
                 schema: schema,
                 request: """
-                query echo($field1: String) {
+                query echo($field1: String = "defaultValue1") {
                     echo (
                         field1: $field1
                     ) {
@@ -706,6 +725,29 @@ class InputTests : XCTestCase {
             GraphQLResult(data: [
                 "echo": [
                     "field1": "defaultValue1"
+                ]
+            ])
+        )
+        
+        // Test that nullable unprovided variables are coerced to null
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo (
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [:]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
                 ]
             ])
         )

--- a/Tests/GraphQLTests/InputTests/InputTests.swift
+++ b/Tests/GraphQLTests/InputTests/InputTests.swift
@@ -6,7 +6,7 @@ import NIO
 class InputTests : XCTestCase {
     
     // Test that input objects parse as expected from non-null literals
-    func testInputParsing() throws {
+    func testInputNoNull() throws {
         struct Echo : Codable {
             let field1: String?
             let field2: String?
@@ -86,6 +86,7 @@ class InputTests : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         
+        // Test in arguments
         XCTAssertEqual(
             try graphql(
                 schema: schema,
@@ -101,6 +102,34 @@ class InputTests : XCTestCase {
                 }
                 """,
                 eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1",
+                    "field2": "value2",
+                ]
+            ])
+        )
+        
+        // Test in variables
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($input: EchoInput) {
+                    echo(input: $input) {
+                        field1
+                        field2
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "input": [
+                        "field1": "value1",
+                        "field2": "value2"
+                    ]
+                ]
             ).wait(),
             GraphQLResult(data: [
                 "echo": [
@@ -192,6 +221,7 @@ class InputTests : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         
+        // Test in arguments
         XCTAssertEqual(
             try graphql(
                 schema: schema,
@@ -207,6 +237,34 @@ class InputTests : XCTestCase {
                 }
                 """,
                 eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1",
+                    "field2": nil,
+                ]
+            ])
+        )
+        
+        // Test in variables
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($input: EchoInput) {
+                    echo(input: $input) {
+                        field1
+                        field2
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "input": [
+                        "field1": "value1",
+                        "field2": .null
+                    ]
+                ]
             ).wait(),
             GraphQLResult(data: [
                 "echo": [
@@ -298,6 +356,7 @@ class InputTests : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         
+        // Test in arguments
         XCTAssertEqual(
             try graphql(
                 schema: schema,
@@ -312,6 +371,33 @@ class InputTests : XCTestCase {
                 }
                 """,
                 eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1",
+                    "field2": nil,
+                ]
+            ])
+        )
+        
+        // Test in variables
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($input: EchoInput) {
+                    echo(input: $input) {
+                        field1
+                        field2
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "input": [
+                        "field1": "value1"
+                    ]
+                ]
             ).wait(),
             GraphQLResult(data: [
                 "echo": [
@@ -404,6 +490,7 @@ class InputTests : XCTestCase {
             XCTAssertNoThrow(try group.syncShutdownGracefully())
         }
         
+        // Undefined with default gets default
         XCTAssertEqual(
             try graphql(
                 schema: schema,
@@ -423,6 +510,85 @@ class InputTests : XCTestCase {
                 "echo": [
                     "field1": "value1",
                     "field2": "value2",
+                ]
+            ])
+        )
+        // Null literal with default gets null
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(input:{
+                        field1: "value1"
+                        field2: null
+                    }) {
+                        field1
+                        field2
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1",
+                    "field2": nil,
+                ]
+            ])
+        )
+        
+        // Test in variable
+        // Undefined with default gets default
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($input: EchoInput) {
+                    echo(input: $input) {
+                        field1
+                        field2
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "input": [
+                        "field1": "value1"
+                    ]
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1",
+                    "field2": "value2",
+                ]
+            ])
+        )
+        // Null literal with default gets null
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($input: EchoInput) {
+                    echo(input: $input) {
+                        field1
+                        field2
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "input": [
+                        "field1": "value1",
+                        "field2": .null
+                    ]
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1",
+                    "field2": nil,
                 ]
             ])
         )

--- a/Tests/GraphQLTests/InputTests/InputTests.swift
+++ b/Tests/GraphQLTests/InputTests/InputTests.swift
@@ -5,6 +5,712 @@ import NIO
 
 class InputTests : XCTestCase {
     
+    func testArgsNonNullNoDefault() throws {
+        struct Echo : Codable {
+            let field1: String
+        }
+        
+        struct EchoArgs : Codable {
+            let field1: String
+        }
+        
+        let EchoOutputType = try! GraphQLObjectType(
+            name: "Echo",
+            description: "",
+            fields: [
+                "field1": GraphQLField(
+                    type: GraphQLNonNull(GraphQLString)
+                ),
+            ],
+            isTypeOf: { source, _, _ in
+                source is Echo
+            }
+        )
+        
+        let schema = try! GraphQLSchema(
+            query: try! GraphQLObjectType(
+                name: "Query",
+                fields: [
+                    "echo": GraphQLField(
+                        type: EchoOutputType,
+                        args: [
+                            "field1": GraphQLArgument(
+                                type: GraphQLNonNull(GraphQLString)
+                            )
+                        ],
+                        resolve: { _, arguments, _, _ in
+                            let args = try MapDecoder().decode(EchoArgs.self, from: arguments)
+                            return Echo(
+                                field1: args.field1
+                            )
+                        }
+                    ),
+                ]
+            ),
+            types: [EchoOutputType]
+        )
+        
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        
+        // Test basic functionality
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: "value1"
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": "value1"
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        
+        // Test providing null results in an error
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: null
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait()
+            .errors.count > 0
+        )
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": .null
+                ]
+            ).wait()
+            .errors.count > 0
+        )
+        
+        // Test not providing parameter results in an error
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait()
+            .errors.count > 0
+        )
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [:]
+            ).wait()
+            .errors.count > 0
+        )
+    }
+    
+    func testArgsNullNoDefault() throws {
+        struct Echo : Codable {
+            let field1: String?
+        }
+        
+        struct EchoArgs : Codable {
+            let field1: String?
+        }
+        
+        let EchoOutputType = try! GraphQLObjectType(
+            name: "Echo",
+            description: "",
+            fields: [
+                "field1": GraphQLField(
+                    type: GraphQLString
+                ),
+            ],
+            isTypeOf: { source, _, _ in
+                source is Echo
+            }
+        )
+        
+        let schema = try! GraphQLSchema(
+            query: try! GraphQLObjectType(
+                name: "Query",
+                fields: [
+                    "echo": GraphQLField(
+                        type: EchoOutputType,
+                        args: [
+                            "field1": GraphQLArgument(
+                                type: GraphQLString
+                            )
+                        ],
+                        resolve: { _, arguments, _, _ in
+                            let args = try MapDecoder().decode(EchoArgs.self, from: arguments)
+                            return Echo(
+                                field1: args.field1
+                            )
+                        }
+                    ),
+                ]
+            ),
+            types: [EchoOutputType]
+        )
+        
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        
+        // Test basic functionality
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: "value1"
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": "value1"
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        
+        // Test providing null is accepted
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: null
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": .null
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
+                ]
+            ])
+        )
+        
+        // Test not providing parameter is accepted
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [:]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
+                ]
+            ])
+        )
+    }
+    
+    func testArgsNonNullDefault() throws {
+        struct Echo : Codable {
+            let field1: String
+        }
+        
+        struct EchoArgs : Codable {
+            let field1: String
+        }
+        
+        let EchoOutputType = try! GraphQLObjectType(
+            name: "Echo",
+            description: "",
+            fields: [
+                "field1": GraphQLField(
+                    type: GraphQLNonNull(GraphQLString)
+                ),
+            ],
+            isTypeOf: { source, _, _ in
+                source is Echo
+            }
+        )
+        
+        let schema = try! GraphQLSchema(
+            query: try! GraphQLObjectType(
+                name: "Query",
+                fields: [
+                    "echo": GraphQLField(
+                        type: EchoOutputType,
+                        args: [
+                            "field1": GraphQLArgument(
+                                type: GraphQLNonNull(GraphQLString),
+                                defaultValue: .string("defaultValue1")
+                            )
+                        ],
+                        resolve: { _, arguments, _, _ in
+                            let args = try MapDecoder().decode(EchoArgs.self, from: arguments)
+                            return Echo(
+                                field1: args.field1
+                            )
+                        }
+                    ),
+                ]
+            ),
+            types: [EchoOutputType]
+        )
+        
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        
+        // Test basic functionality
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: "value1"
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": "value1"
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        
+        // Test providing null results in an error
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: null
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait()
+            .errors.count > 0
+        )
+        XCTAssertTrue(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": .null
+                ]
+            ).wait()
+            .errors.count > 0
+        )
+        
+        // Test not providing parameter results in default
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "defaultValue1"
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo (
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [:]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "defaultValue1"
+                ]
+            ])
+        )
+    }
+    
+    func testArgsNullDefault() throws {
+        struct Echo : Codable {
+            let field1: String?
+        }
+        
+        struct EchoArgs : Codable {
+            let field1: String?
+        }
+        
+        let EchoOutputType = try! GraphQLObjectType(
+            name: "Echo",
+            description: "",
+            fields: [
+                "field1": GraphQLField(
+                    type: GraphQLString
+                ),
+            ],
+            isTypeOf: { source, _, _ in
+                source is Echo
+            }
+        )
+        
+        let schema = try! GraphQLSchema(
+            query: try! GraphQLObjectType(
+                name: "Query",
+                fields: [
+                    "echo": GraphQLField(
+                        type: EchoOutputType,
+                        args: [
+                            "field1": GraphQLArgument(
+                                type: GraphQLString,
+                                defaultValue: .string("defaultValue1")
+                            )
+                        ],
+                        resolve: { _, arguments, _, _ in
+                            let args = try MapDecoder().decode(EchoArgs.self, from: arguments)
+                            return Echo(
+                                field1: args.field1
+                            )
+                        }
+                    ),
+                ]
+            ),
+            types: [EchoOutputType]
+        )
+        
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+        defer {
+            XCTAssertNoThrow(try group.syncShutdownGracefully())
+        }
+        
+        // Test basic functionality
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: "value1"
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String!) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": "value1"
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "value1"
+                ]
+            ])
+        )
+        
+        // Test providing null results in a null output
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo(
+                        field1: null
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo(
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [
+                    "field1": .null
+                ]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": .null
+                ]
+            ])
+        )
+        
+        // Test not providing parameter results in default
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                {
+                    echo {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "defaultValue1"
+                ]
+            ])
+        )
+        XCTAssertEqual(
+            try graphql(
+                schema: schema,
+                request: """
+                query echo($field1: String) {
+                    echo (
+                        field1: $field1
+                    ) {
+                        field1
+                    }
+                }
+                """,
+                eventLoopGroup: group,
+                variableValues: [:]
+            ).wait(),
+            GraphQLResult(data: [
+                "echo": [
+                    "field1": "defaultValue1"
+                ]
+            ])
+        )
+    }
+    
     // Test that input objects parse as expected from non-null literals
     func testInputNoNull() throws {
         struct Echo : Codable {


### PR DESCRIPTION
This is a follow-up to https://github.com/GraphQLSwift/GraphQL/pull/87. That PR added support to differentiate between *explicitly providing the literal value null* and *implicitly not providing a value at all* in input objects provided in the arguments. This merge request extends that functionality to input objects in variables and non-object arguments.

It also fixes a bug with not pre-validating argument inputs against their type (for example, passing null to a non-null parameter would passed null all the way into the resolver). It also removes force-casts to harden against server-wide fatal errors.