### PR TITLE
Error extensions support

### DIFF
--- a/Sources/GraphQL/Extensions/Codable+Extensions.swift
+++ b/Sources/GraphQL/Extensions/Codable+Extensions.swift
@@ -9,3 +9,38 @@ public class AnyEncodable : Encodable {
         return try self.encodable.encode(to: encoder)
     }
 }
+
+public class AnyCodable : Codable {
+    private let codable: Codable
+    
+    public init(_ codable: Codable) {
+        self.codable = codable
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        return try self.codable.encode(to: encoder)
+    }
+    
+    required public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if container.decodeNil() {
+            self.codable = "Null"
+        } else if let bool = try? container.decode(Bool.self) {
+            self.codable = bool
+        } else if let int = try? container.decode(Int.self) {
+            self.codable = int
+        } else if let uint = try? container.decode(UInt.self) {
+            self.codable = uint
+        } else if let double = try? container.decode(Double.self) {
+            self.codable = double
+        } else if let string = try? container.decode(String.self) {
+            self.codable = string
+        } else if let array = try? container.decode([AnyCodable].self) {
+            codable = array
+        } else if let dictionary = try? container.decode([String: AnyCodable].self) {
+            codable = dictionary
+        } else {
+            throw DecodingError.dataCorruptedError(in: container, debugDescription: "AnyCodable: can't decode value")
+        }
+    }
+}

--- a/Sources/GraphQL/Extensions/Error+Extensions.swift
+++ b/Sources/GraphQL/Extensions/Error+Extensions.swift
@@ -1,0 +1,13 @@
+public extension Error {
+    var reflection: [String: AnyCodable] {
+        let errorReflection: Mirror = Mirror(reflecting: self)
+        return Dictionary(uniqueKeysWithValues: errorReflection.children.lazy.map({ (label: String?, value: Any) -> (String, AnyCodable)? in
+            guard let key = label,
+                  let codableValue = value as? Codable else {
+                      return nil
+            }
+            
+            return (key, AnyCodable(codableValue))
+        }).compactMap { $0 })
+    }
+}


### PR DESCRIPTION
Following [GraphQLError extension to add error code #72](https://github.com/GraphQLSwift/Graphiti/issues/72) on [Graphiti](https://github.com/GraphQLSwift/Graphiti).   
I was looking for a better way to handle GraphQL errors on client.   
Inspired by  [Apollo Server error extensions](https://www.apollographql.com/docs/apollo-server/data/errors/) I was looking for something similar for my Vapor server.

### Swift `Error` protocol
Most of the times no additional data needed to analyze an error or a thrown exception but the data already exist in a Swift custom error type.
Vapor's `Abort` and `AbortError` for example already have status code, reason, stack trace and even headers.

**Problem 1**
Accessing custom error data without casting it to its actual type is impossible.

**Problem 2**
Even if I can access this data, saving this `Any` as a `Codable` representation will require using some king of meta type or type erasure.

## Codable+Extensions - `AnyCodable`
Inspired by [Flight-School/AnyCodable](https://github.com/Flight-School/AnyCodable) I've crated `AnyCodable` class, along side the existing `AnyEncodable`, that can wrap Any Codable type, and encode\decode it ad a dictionary value.


## Error+Extensions
Using Swift's [Mirror](https://developer.apple.com/documentation/swift/mirror) I was able to create a dictionary representation reflecting all of the error's additional data, that otherwise was hidden to the `GraphQL` module.
I've added a new Swift Error extension to easily create reflection for a given error.
```
public extension Error {
    var reflection: [String: AnyCodable] {
        let errorReflection: Mirror = Mirror(reflecting: self)
        return Dictionary(uniqueKeysWithValues: errorReflection.children.lazy.map({ (label: String?, value: Any) -> (String, AnyCodable)? in
            guard let key = label,
                  let codableValue = value as? Codable else {
                      return nil
            }
            
            return (key, AnyCodable(codableValue))
        }).compactMap { $0 })
    }
}
```

## GraphQLError
Next step was to add `extensions` property to the `GraphQLError` struct.
```
    /**
     * A dictionary containing original error reflection
     * to supply additional data from error extensions.
     *
     * Will reflect only Codable objects.
     *
     * For more information about supported types look at `AnyCodable` - `init(from:)`
     *
     * Appears in the result of `description`.
     */
    public let extensions: [String: AnyCodable]?
```

## The result
Now error description response contains a new `extensions` field that reflect any additional data held by the original error.
```
{
    "errors": [
        {
            "path": [
                “getMe
            ],
            "message": "Abort.401: Unauthorized",
            "extensions": {
                "status": 401,
                "reason": "Unauthorized",
                "identifier": “401”,
                "headers": {
                    “header1": “some header”,
                    “header2”: "some other header”
                }
            },
            "locations": [
                {
                    "line": 2,
                    "column": 3
                }
            ]
        }
    ]
}
```

### TODOs and other considerations

- The `AnyCodable` class does not represent nil values as for now, any nil decoded value will be presented as "Null" string
- `AnyCodable` supported types can be found on the `init(from:)` initializer. any new type that we want to support in the future will have to be added manually.
- I can't seems to find an easy way to add a kill switch to this feature, in case some user will decide he does not want to reveal this data to the client.
