### PR TITLE
Making validate with validation rules public

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "51c3fc2e4a0fcdf4a25089b288dd65b73df1b0ef",
-          "version": "2.37.0"
+          "revision": "124119f0bb12384cef35aa041d7c3a686108722d",
+          "version": "2.40.0"
         }
       }
     ]

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -78,6 +78,7 @@ public func graphql(
     mutationStrategy: MutationFieldExecutionStrategy = SerialFieldExecutionStrategy(),
     subscriptionStrategy: SubscriptionFieldExecutionStrategy = SerialFieldExecutionStrategy(),
     instrumentation: Instrumentation = NoOpInstrumentation,
+    validationRules: [(ValidationContext) -> Visitor] = [],
     schema: GraphQLSchema,
     request: String,
     rootValue: Any = (),
@@ -89,7 +90,7 @@ public func graphql(
 
     let source = Source(body: request, name: "GraphQL request")
     let documentAST = try parse(instrumentation: instrumentation, source: source)
-    let validationErrors = validate(instrumentation: instrumentation, schema: schema, ast: documentAST)
+    let validationErrors = validate(instrumentation: instrumentation, schema: schema, ast: documentAST, rules: validationRules)
 
     guard validationErrors.isEmpty else {
         return eventLoopGroup.next().makeSucceededFuture(GraphQLResult(errors: validationErrors))
@@ -195,6 +196,7 @@ public func graphqlSubscribe(
     mutationStrategy: MutationFieldExecutionStrategy = SerialFieldExecutionStrategy(),
     subscriptionStrategy: SubscriptionFieldExecutionStrategy = SerialFieldExecutionStrategy(),
     instrumentation: Instrumentation = NoOpInstrumentation,
+    validationRules: [(ValidationContext) -> Visitor] = [],
     schema: GraphQLSchema,
     request: String,
     rootValue: Any = (),
@@ -206,7 +208,7 @@ public func graphqlSubscribe(
 
     let source = Source(body: request, name: "GraphQL Subscription request")
     let documentAST = try parse(instrumentation: instrumentation, source: source)
-    let validationErrors = validate(instrumentation: instrumentation, schema: schema, ast: documentAST)
+    let validationErrors = validate(instrumentation: instrumentation, schema: schema, ast: documentAST, rules: validationRules)
 
     guard validationErrors.isEmpty else {
         return eventLoopGroup.next().makeSucceededFuture(SubscriptionResult(errors: validationErrors))

--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -313,13 +313,13 @@ func visitInParallel(visitors: [Visitor]) -> Visitor {
     )
 }
 
-enum VisitResult {
+public enum VisitResult {
     case `continue`
     case skip
     case `break`
     case node(Node?)
 
-    var isContinue: Bool {
+    public var isContinue: Bool {
         if case .continue = self {
             return true
         }
@@ -327,26 +327,26 @@ enum VisitResult {
     }
 }
 
-struct Visitor {
-    typealias Visit = (Node, IndexPathElement?, NodeResult?, [IndexPathElement], [NodeResult]) -> VisitResult
+public struct Visitor {
+    public typealias Visit = (Node, IndexPathElement?, NodeResult?, [IndexPathElement], [NodeResult]) -> VisitResult
     private let enter: Visit
     private let leave: Visit
 
-    init(enter: @escaping Visit = ignore, leave: @escaping Visit = ignore) {
+    public init(enter: @escaping Visit = ignore, leave: @escaping Visit = ignore) {
         self.enter = enter
         self.leave = leave
     }
 
-    func enter(node: Node, key: IndexPathElement?, parent: NodeResult?, path: [IndexPathElement], ancestors: [NodeResult]) -> VisitResult {
+    public func enter(node: Node, key: IndexPathElement?, parent: NodeResult?, path: [IndexPathElement], ancestors: [NodeResult]) -> VisitResult {
         return enter(node, key, parent, path, ancestors)
     }
 
-    func leave(node: Node, key: IndexPathElement?, parent: NodeResult?, path: [IndexPathElement], ancestors: [NodeResult]) -> VisitResult {
+    public func leave(node: Node, key: IndexPathElement?, parent: NodeResult?, path: [IndexPathElement], ancestors: [NodeResult]) -> VisitResult {
         return leave(node, key, parent, path, ancestors)
     }
 }
 
-func ignore(node: Node, key: IndexPathElement?, parent: NodeResult?, path: [IndexPathElement], ancestors: [NodeResult]) -> VisitResult {
+public func ignore(node: Node, key: IndexPathElement?, parent: NodeResult?, path: [IndexPathElement], ancestors: [NodeResult]) -> VisitResult {
     return .continue
 }
 

--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -327,7 +327,10 @@ public enum VisitResult {
     }
 }
 
+/// A visitor is provided to visit, it contains the collection of
+/// relevant functions to be called during the visitor's traversal.
 public struct Visitor {
+    /// A visitor is comprised of visit functions, which are called on each node during the visitor's traversal.
     public typealias Visit = (Node, IndexPathElement?, NodeResult?, [IndexPathElement], [NodeResult]) -> VisitResult
     private let enter: Visit
     private let leave: Visit

--- a/Sources/GraphQL/Validation/SpecifiedRules.swift
+++ b/Sources/GraphQL/Validation/SpecifiedRules.swift
@@ -1,7 +1,7 @@
 /**
  * This set includes all validation rules defined by the GraphQL spec.
  */
-let specifiedRules: [(ValidationContext) -> Visitor] = [
+public let specifiedRules: [(ValidationContext) -> Visitor] = [
 //    UniqueOperationNames,
 //    LoneAnonymousOperation,
 //    KnownTypeNames,

--- a/Sources/GraphQL/Validation/Validate.swift
+++ b/Sources/GraphQL/Validation/Validate.swift
@@ -29,7 +29,7 @@ public func validate(
  * (see the language/visitor API). Visitor methods are expected to return
  * GraphQLErrors, or Arrays of GraphQLErrors when invalid.
  */
-func validate(
+public func validate(
     instrumentation: Instrumentation = NoOpInstrumentation,
     schema: GraphQLSchema,
     ast: Document,

--- a/Sources/GraphQL/Validation/Validate.swift
+++ b/Sources/GraphQL/Validation/Validate.swift
@@ -62,11 +62,11 @@ func visit(
     return context.errors
 }
 
-enum HasSelectionSet {
+public enum HasSelectionSet {
     case operation(OperationDefinition)
     case fragment(FragmentDefinition)
 
-    var node: Node {
+    public var node: Node {
         switch self {
         case .operation(let operation):
             return operation
@@ -77,7 +77,7 @@ enum HasSelectionSet {
 }
 
 extension HasSelectionSet : Hashable {
-    func hash(into hasher: inout Hasher) {
+    public func hash(into hasher: inout Hasher) {
         switch self {
         case .operation(let operation):
             return hasher.combine(operation.hashValue)
@@ -86,7 +86,7 @@ extension HasSelectionSet : Hashable {
         }
     }
 
-    static func == (lhs: HasSelectionSet, rhs: HasSelectionSet) -> Bool {
+    public static func == (lhs: HasSelectionSet, rhs: HasSelectionSet) -> Bool {
         switch (lhs, rhs) {
         case (.operation(let l), .operation(let r)):
             return l == r
@@ -98,15 +98,15 @@ extension HasSelectionSet : Hashable {
     }
 }
 
-typealias VariableUsage = (node: Variable, type: GraphQLInputType?)
+public typealias VariableUsage = (node: Variable, type: GraphQLInputType?)
 
 /**
  * An instance of this class is passed as the "this" context to all validators,
  * allowing access to commonly useful contextual information from within a
  * validation rule.
  */
-final class ValidationContext {
-    let schema: GraphQLSchema
+public final class ValidationContext {
+    public let schema: GraphQLSchema
     let ast: Document
     let typeInfo: TypeInfo
     var errors: [GraphQLError]
@@ -128,11 +128,11 @@ final class ValidationContext {
         self.recursiveVariableUsages = [:]
     }
 
-    func report(error: GraphQLError) {
+    public func report(error: GraphQLError) {
         errors.append(error)
     }
 
-    func getFragment(name: String) -> FragmentDefinition? {
+    public func getFragment(name: String) -> FragmentDefinition? {
         var fragments = self.fragments
 
         if fragments.isEmpty {
@@ -152,7 +152,7 @@ final class ValidationContext {
         return fragments[name]
     }
 
-    func getFragmentSpreads(node: SelectionSet) -> [FragmentSpread] {
+    public func getFragmentSpreads(node: SelectionSet) -> [FragmentSpread] {
         var spreads = fragmentSpreads[node]
 
         if spreads == nil {
@@ -181,7 +181,7 @@ final class ValidationContext {
         return spreads!
     }
 
-    func getRecursivelyReferencedFragments(operation: OperationDefinition) -> [FragmentDefinition] {
+    public func getRecursivelyReferencedFragments(operation: OperationDefinition) -> [FragmentDefinition] {
         var fragments = recursivelyReferencedFragments[operation]
 
         if fragments == nil {
@@ -210,7 +210,7 @@ final class ValidationContext {
         return fragments!
     }
 
-    func getVariableUsages(node: HasSelectionSet) -> [VariableUsage] {
+    public func getVariableUsages(node: HasSelectionSet) -> [VariableUsage] {
         var usages = variableUsages[node]
 
         if usages == nil {
@@ -236,7 +236,7 @@ final class ValidationContext {
         return usages!
     }
 
-    func getRecursiveVariableUsages(operation: OperationDefinition) -> [VariableUsage] {
+    public func getRecursiveVariableUsages(operation: OperationDefinition) -> [VariableUsage] {
         var usages = recursiveVariableUsages[operation]
 
         if usages == nil {
@@ -254,27 +254,27 @@ final class ValidationContext {
         return usages!
     }
 
-    var type: GraphQLOutputType? {
+    public var type: GraphQLOutputType? {
         return typeInfo.type
     }
 
-    var parentType: GraphQLCompositeType? {
+    public var parentType: GraphQLCompositeType? {
         return typeInfo.parentType
     }
 
-    var inputType: GraphQLInputType? {
+    public var inputType: GraphQLInputType? {
         return typeInfo.inputType
     }
 
-    var fieldDef: GraphQLFieldDefinition? {
+    public var fieldDef: GraphQLFieldDefinition? {
         return typeInfo.fieldDef
     }
 
-    var directive: GraphQLDirective? {
+    public var directive: GraphQLDirective? {
         return typeInfo.directive
     }
 
-    var argument: GraphQLArgumentDefinition? {
+    public var argument: GraphQLArgumentDefinition? {
         return typeInfo.argument
     }
 }


### PR DESCRIPTION
Following #98,

I was looking for a way to specify custom validation rules and use them to validate GraphQL requests, which would allow something like [GraphQL Query Cost Analysis](https://www.npmjs.com/package/graphql-cost-analysis), [GraphQL Depth Limit](https://www.npmjs.com/package/graphql-depth-limit), etc. 