### PR TITLE
Fixing issues with ConcurrentEventStream from #101

### DIFF
--- a/Sources/GraphQL/Subscription/EventStream.swift
+++ b/Sources/GraphQL/Subscription/EventStream.swift
@@ -31,7 +31,7 @@ public class ConcurrentEventStream<Element>: EventStream<Element> {
 extension AsyncThrowingStream {
     func mapStream<To>(_ closure: @escaping (Element) throws -> To) -> AsyncThrowingStream<To, Error> {
         return AsyncThrowingStream<To, Error> { continuation in
-            let task = Task {
+            Task {
                 do {
                     for try await event in self {
                         let newEvent = try closure(event)
@@ -42,18 +42,12 @@ extension AsyncThrowingStream {
                     continuation.finish(throwing: error)
                 }
             }
-
-            continuation.onTermination = { @Sendable reason in
-                if case .cancelled = reason {
-                    task.cancel()
-                }
-            }
         }
     }
     
     func filterStream(_ isIncluded: @escaping (Element) throws -> Bool) -> AsyncThrowingStream<Element, Error> {
         return AsyncThrowingStream<Element, Error> { continuation in
-            let task = Task {
+            Task {
                 do {
                     for try await event in self {
                         if try isIncluded(event) {
@@ -63,12 +57,6 @@ extension AsyncThrowingStream {
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
-                }
-            }
-
-            continuation.onTermination = { @Sendable reason in 
-                if case .cancelled = reason {
-                    task.cancel()
                 }
             }
         }

--- a/Sources/GraphQL/Subscription/EventStream.swift
+++ b/Sources/GraphQL/Subscription/EventStream.swift
@@ -43,8 +43,10 @@ extension AsyncThrowingStream {
                 }
             }
 
-            continuation.onTermination = { @Sendable _ in
-                task.cancel()
+            continuation.onTermination = { @Sendable reason in
+                if case .cancelled = reason {
+                    task.cancel()
+                }
             }
         }
     }
@@ -64,8 +66,10 @@ extension AsyncThrowingStream {
                 }
             }
 
-            continuation.onTermination = { @Sendable _ in 
-                task.cancel()
+            continuation.onTermination = { @Sendable reason in 
+                if case .cancelled = reason {
+                    task.cancel()
+                }
             }
         }
     }

--- a/Tests/GraphQLTests/SubscriptionTests/SubscriptionTests.swift
+++ b/Tests/GraphQLTests/SubscriptionTests/SubscriptionTests.swift
@@ -605,12 +605,15 @@ class SubscriptionTests : XCTestCase {
         
         var results = [GraphQLResult]()
         var expectation = XCTestExpectation()
-        _ = stream.map { event in
+        
+        // So that the Task won't immediately be cancelled since the ConcurrentEventStream is discarded
+        let keepForNow = stream.map { event in
             event.map { result in
                 results.append(result)
                 expectation.fulfill()
             }
         }
+
         var expected = [GraphQLResult]()
         
         db.trigger(email: Email(
@@ -675,6 +678,9 @@ class SubscriptionTests : XCTestCase {
         )
         wait(for: [expectation], timeout: timeoutDuration)
         XCTAssertEqual(results, expected)
+
+        // So that the Task won't immediately be cancelled since the ConcurrentEventStream is discarded
+        _ = keepForNow
     }
 
     /// 'should not trigger when subscription is already done'
@@ -701,7 +707,8 @@ class SubscriptionTests : XCTestCase {
         
         var results = [GraphQLResult]()
         var expectation = XCTestExpectation()
-        _ = stream.map { event in
+        // So that the Task won't immediately be cancelled since the ConcurrentEventStream is discarded
+        let keepForNow = stream.map { event in
             event.map { result in
                 results.append(result)
                 expectation.fulfill()
@@ -747,6 +754,9 @@ class SubscriptionTests : XCTestCase {
         // Ensure that the current result was the one before the db was stopped
         wait(for: [expectation], timeout: timeoutDuration)
         XCTAssertEqual(results, expected)
+
+        // So that the Task won't immediately be cancelled since the ConcurrentEventStream is discarded
+        _ = keepForNow
     }
 
     /// 'should not trigger when subscription is thrown'
@@ -861,7 +871,8 @@ class SubscriptionTests : XCTestCase {
         
         var results = [GraphQLResult]()
         var expectation = XCTestExpectation()
-        _ = stream.map { event in
+        // So that the Task won't immediately be cancelled since the ConcurrentEventStream is discarded
+        let keepForNow = stream.map { event in
             event.map { result in
                 results.append(result)
                 expectation.fulfill()
@@ -925,6 +936,9 @@ class SubscriptionTests : XCTestCase {
         )
         wait(for: [expectation], timeout: timeoutDuration)
         XCTAssertEqual(results, expected)
+
+        // So that the Task won't immediately be cancelled since the ConcurrentEventStream is discarded
+        _ = keepForNow
     }
     
     /// 'should pass through error thrown in source event stream'


### PR DESCRIPTION
Addressing issue #101 

- Updated `.mapStream` and `.filterStream` to catch thrown error and pass it to the next/transformed stream
- Updated `.mapStream` and `.filterStream` to call `continuation.finish()` when the source stream ended/finished with no error
- Updated `.mapStream` and `.filterStream` to cancel `Task` used to consume source stream when it has been terminated
- Updated SubscriptionsTest's `testNoTriggerAfterDone `, `testErrorDuringSubscription `, and `testArguments` to not discard the `ConcurrentEventStream` which would close all `Task` used to perform transformations of element (Previously was not an issue because of the leak that keep the `Task` alive).