### PR TITLE
Code safety improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore: [ README.md ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths-ignore: [ README.md ]
   workflow_dispatch:
 

--- a/Sources/GraphQL/Error/SyntaxError.swift
+++ b/Sources/GraphQL/Error/SyntaxError.swift
@@ -50,16 +50,19 @@ func highlightSourceAtLocation(source: Source, location: SourceLocation) -> Stri
 
 func splitLines(string: String) -> [String] {
 
-    let nsstring = NSString(string: string)
-    let regex = try! NSRegularExpression(pattern: "\r\n|[\n\r]", options: [])
-
     var lines: [String] = []
     var location = 0
-
-    for match in regex.matches(in: string, options: [], range: NSRange(0..<nsstring.length)) {
-        let range = NSRange(location..<match.range.location)
-        lines.append(nsstring.substring(with: range))
-        location =  match.range.location + match.range.length
+    
+    let nsstring = NSString(string: string)
+    do {
+        let regex = try NSRegularExpression(pattern: "\r\n|[\n\r]", options: [])
+        for match in regex.matches(in: string, options: [], range: NSRange(0..<nsstring.length)) {
+            let range = NSRange(location..<match.range.location)
+            lines.append(nsstring.substring(with: range))
+            location =  match.range.location + match.range.length
+        }
+    } catch {
+        // Let lines and location remain unchanged
     }
 
     if lines.isEmpty {

--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -670,7 +670,7 @@ public func resolveField(
     let fieldAST = fieldASTs[0]
     let fieldName = fieldAST.name.value
 
-    let fieldDef = getFieldDef(
+    let fieldDef = try getFieldDef(
         schema: exeContext.schema,
         parentType: parentType,
         fieldName: fieldName
@@ -1195,7 +1195,7 @@ func getFieldDef(
     schema: GraphQLSchema,
     parentType: GraphQLObjectType,
     fieldName: String
-) -> GraphQLFieldDefinition {
+) throws -> GraphQLFieldDefinition {
     if fieldName == SchemaMetaFieldDef.name && schema.queryType.name == parentType.name {
         return SchemaMetaFieldDef
     } else if fieldName == TypeMetaFieldDef.name && schema.queryType.name == parentType.name {
@@ -1203,7 +1203,10 @@ func getFieldDef(
     } else if fieldName == TypeNameMetaFieldDef.name {
         return TypeNameMetaFieldDef
     }
-
-    // we know this field exists because we passed validation before execution
-    return parentType.fields[fieldName]!
+    
+    // This field should exist because we passed validation before execution
+    guard let fieldDefinition = parentType.fields[fieldName] else {
+        throw GraphQLError(message: "Expected field definition not found: '\(fieldName)' on '\(parentType.name)'")
+    }
+    return fieldDefinition
 }

--- a/Sources/GraphQL/Execution/Execute.swift
+++ b/Sources/GraphQL/Execution/Execute.swift
@@ -796,7 +796,7 @@ func completeValueCatchingError(
             result: result
         ).flatMapError { error -> EventLoopFuture<Any?> in
             guard let error = error as? GraphQLError else {
-                fatalError()
+                return exeContext.eventLoopGroup.next().makeFailedFuture(error)
             }
             exeContext.append(error: error)
             return exeContext.eventLoopGroup.next().makeSucceededFuture(nil)
@@ -809,7 +809,7 @@ func completeValueCatchingError(
         exeContext.append(error: error)
         return exeContext.eventLoopGroup.next().makeSucceededFuture(nil)
     } catch {
-        fatalError()
+        return exeContext.eventLoopGroup.next().makeFailedFuture(error)
     }
 }
 

--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -33,8 +33,11 @@ public struct GraphQLResult : Equatable, Codable, CustomStringConvertible {
     }
     
     public var description: String {
-        let data = try! GraphQLJSONEncoder().encode(self)
-        return String(data: data, encoding: .utf8)!
+        guard let data = try? GraphQLJSONEncoder().encode(self),
+              let dataString = String(data: data, encoding: .utf8) else {
+            return "Unable to encode GraphQLResult"
+        }
+        return dataString
     }
 }
 

--- a/Sources/GraphQL/Language/Location.swift
+++ b/Sources/GraphQL/Language/Location.swift
@@ -18,13 +18,15 @@ func getLocation(source: Source, position: Int) -> SourceLocation {
     var line = 1
     var column = position + 1
 
-    let regex = try! NSRegularExpression(pattern: "\r\n|[\n\r]", options: [])
-
-    let matches = regex.matches(in: source.body, options: [], range: NSRange(0..<source.body.utf16.count))
-
-    for match in matches where match.range.location < position {
-        line += 1
-        column = position + 1 - (match.range.location + match.range.length)
+    do {
+        let regex = try NSRegularExpression(pattern: "\r\n|[\n\r]", options: [])
+        let matches = regex.matches(in: source.body, options: [], range: NSRange(0..<source.body.utf16.count))
+        for match in matches where match.range.location < position {
+            line += 1
+            column = position + 1 - (match.range.location + match.range.length)
+        }
+    } catch {
+        // Leave line and position unset if regex fails
     }
 
     return SourceLocation(line: line, column: column)

--- a/Sources/GraphQL/Map/AnySerialization.swift
+++ b/Sources/GraphQL/Map/AnySerialization.swift
@@ -6,6 +6,15 @@ public struct AnySerialization {
     }
     
     static func object(with map: Any) throws -> NSObject {
-        return map as! NSObject
+        guard let result = map as? NSObject else {
+            throw EncodingError.invalidValue(
+                map,
+                EncodingError.Context(
+                    codingPath: [],
+                    debugDescription: "Expected object input to be castable to NSObject: \(type(of: map))"
+                )
+            )
+        }
+        return result
     }
 }

--- a/Sources/GraphQL/Map/Map.swift
+++ b/Sources/GraphQL/Map/Map.swift
@@ -663,7 +663,13 @@ extension Map : Codable {
         
         switch self {
         case .undefined:
-            fatalError("undefined values should have been excluded from encoding")
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: [],
+                    debugDescription: "undefined values should have been excluded from encoding"
+                )
+            )
         case .null:
             try container.encodeNil()
         case let .bool(value):

--- a/Sources/GraphQL/Map/Map.swift
+++ b/Sources/GraphQL/Map/Map.swift
@@ -687,7 +687,15 @@ extension Map : Codable {
             var container = encoder.container(keyedBy: _DictionaryCodingKey.self)
             for (key, value) in dictionary {
                 if !value.isUndefined {
-                    let codingKey = _DictionaryCodingKey(stringValue: key)!
+                    guard let codingKey = _DictionaryCodingKey(stringValue: key) else {
+                        throw EncodingError.invalidValue(
+                            self,
+                            EncodingError.Context(
+                                codingPath: [],
+                                debugDescription: "codingKey not found for dictionary key: \(key)"
+                            )
+                        )
+                    }
                     try container.encode(value, forKey: codingKey)
                 }
             }

--- a/Sources/GraphQL/Map/MapSerialization.swift
+++ b/Sources/GraphQL/Map/MapSerialization.swift
@@ -35,7 +35,13 @@ public struct MapSerialization {
     static func object(with map: Map) throws -> NSObject {
         switch map {
         case .undefined:
-            fatalError("undefined values should have been excluded from serialization")
+            throw EncodingError.invalidValue(
+                self,
+                EncodingError.Context(
+                    codingPath: [],
+                    debugDescription: "undefined values should have been excluded from serialization"
+                )
+            )
         case .null:
             return NSNull()
         case let .bool(value):

--- a/Sources/GraphQL/Map/MapSerialization.swift
+++ b/Sources/GraphQL/Map/MapSerialization.swift
@@ -12,13 +12,40 @@ public struct MapSerialization {
             return .string(string as String)
         case let array as NSArray:
             let array: [Map] = try array.map { value in
-                try self.map(with: value as! NSObject)
+                guard let value = value as? NSObject else {
+                    throw EncodingError.invalidValue(
+                        array,
+                        EncodingError.Context(
+                            codingPath: [],
+                            debugDescription: "Array value was not an object: \(value) in \(array)"
+                        )
+                    )
+                }
+                return try self.map(with: value)
             }
             return .array(array)
         case let dictionary as NSDictionary:
             // Extract from an unordered dictionary, using NSDictionary extraction order
             let orderedDictionary: OrderedDictionary<String, Map> = try dictionary.reduce(into: [:]) { (dictionary, pair) in
-                dictionary[pair.key as! String] = try self.map(with: pair.value as! NSObject)
+                guard let key = pair.key as? String else {
+                    throw EncodingError.invalidValue(
+                        dictionary,
+                        EncodingError.Context(
+                            codingPath: [],
+                            debugDescription: "Dictionary key was not string: \(pair.key) in \(dictionary)"
+                        )
+                    )
+                }
+                guard let value = pair.value as? NSObject else{
+                    throw EncodingError.invalidValue(
+                        dictionary,
+                        EncodingError.Context(
+                            codingPath: [],
+                            debugDescription: "Dictionary value was not an object: \(key) in \(dictionary)"
+                        )
+                    )
+                }
+                dictionary[key] = try self.map(with: value)
             }
             return .dictionary(orderedDictionary)
         default:

--- a/Sources/GraphQL/Subscription/Subscribe.swift
+++ b/Sources/GraphQL/Subscription/Subscribe.swift
@@ -178,10 +178,15 @@ func executeSubscription(
         fields: &inputFields,
         visitedFragmentNames: &visitedFragmentNames
     )
-    // If query is valid, fields is guaranteed to have at least 1 member
-    let responseName = fields.keys.first!
-    let fieldNodes = fields[responseName]!
-    let fieldNode = fieldNodes.first!
+    
+    // If query is valid, fields should have at least 1 member
+    guard let responseName = fields.keys.first,
+          let fieldNodes = fields[responseName],
+          let fieldNode = fieldNodes.first else {
+        throw GraphQLError(
+            message: "Subscription field resolution resulted in no field nodes."
+        )
+    }
     
     guard let fieldDef = getFieldDef(schema: context.schema, parentType: type, fieldAST: fieldNode) else {
         throw GraphQLError(

--- a/Sources/GraphQL/SwiftUtilities/SuggestionList.swift
+++ b/Sources/GraphQL/SwiftUtilities/SuggestionList.swift
@@ -20,6 +20,7 @@ func suggestionList(
 
     }
     return optionsByDistance.keys.sorted {
+        // Values are guaranteed non-nil since the keys come from the object itself
         optionsByDistance[$0]! - optionsByDistance[$1]! != 0
     }
 }

--- a/Sources/GraphQL/Type/Schema.swift
+++ b/Sources/GraphQL/Type/Schema.swift
@@ -108,7 +108,11 @@ public final class GraphQLSchema {
     public func getImplementations(
         interfaceType: GraphQLInterfaceType
     ) -> InterfaceImplementations {
-        implementations[interfaceType.name]!
+        guard let matchingImplementations = implementations[interfaceType.name] else {
+            // If we ask for an interface that hasn't been defined, just return no types.
+            return InterfaceImplementations.init()
+        }
+        return matchingImplementations
     }
 
     // @deprecated: use isSubType instead - will be removed in the future.

--- a/Sources/GraphQL/Utilities/NIO+Extensions.swift
+++ b/Sources/GraphQL/Utilities/NIO+Extensions.swift
@@ -51,6 +51,7 @@ extension OrderedDictionary where Value : FutureType {
         return EventLoopFuture.whenAllSucceed(futures, on: eventLoopGroup.next()).map { unorderedResult in
             var result: OrderedDictionary<Key, Value.Expectation> = [:]
             for key in keys {
+                // Unwrap is guaranteed because keys are from original dictionary and maps preserve all elements
                 result[key] = unorderedResult.first(where: { $0.0 == key })!.1
             }
             return result

--- a/Sources/GraphQL/Utilities/TypeFromAST.swift
+++ b/Sources/GraphQL/Utilities/TypeFromAST.swift
@@ -7,6 +7,7 @@ func typeFromAST(schema: GraphQLSchema, inputTypeAST: Type) -> GraphQLType? {
     
     if let nonNullType = inputTypeAST as? NonNullType {
         if let innerType = typeFromAST(schema: schema, inputTypeAST: nonNullType.type) {
+            // Non-null types by definition must contain nullable types (since all types are nullable by default)
             return GraphQLNonNull(innerType as! GraphQLNullableType)
         }
     }

--- a/Sources/GraphQL/Utilities/TypeInfo.swift
+++ b/Sources/GraphQL/Utilities/TypeInfo.swift
@@ -90,8 +90,12 @@ final class TypeInfo {
             typeStack.append(type)
 
         case let node as InlineFragment:
-            let typeConditionAST = node.typeCondition
-            let outputType = typeConditionAST != nil ? typeFromAST(schema: schema, inputTypeAST: typeConditionAST!) : self.type
+            let outputType: GraphQLType?
+            if let typeConditionAST = node.typeCondition {
+                outputType = typeFromAST(schema: schema, inputTypeAST: typeConditionAST)
+            } else {
+                outputType = self.type
+            }
             typeStack.append(outputType as? GraphQLOutputType)
 
         case let node as FragmentDefinition:

--- a/Sources/GraphQL/Validation/Rules/FieldsOnCorrectTypeRule.swift
+++ b/Sources/GraphQL/Validation/Rules/FieldsOnCorrectTypeRule.swift
@@ -102,6 +102,7 @@ func getSuggestedTypeNames(
 
         // Suggest interface types based on how common they are.
         let suggestedInterfaceTypes = interfaceUsageCount.keys.sorted {
+            // Unwraps are safe because keys are from object being sorted.
             interfaceUsageCount[$1]! - interfaceUsageCount[$0]! >= 0
         }
 

--- a/Tests/GraphQLTests/InputTests/InputTests.swift
+++ b/Tests/GraphQLTests/InputTests/InputTests.swift
@@ -14,7 +14,7 @@ class InputTests : XCTestCase {
             let field1: String
         }
         
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -27,8 +27,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -180,7 +180,7 @@ class InputTests : XCTestCase {
             let field1: String?
         }
         
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -193,8 +193,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -362,7 +362,7 @@ class InputTests : XCTestCase {
             let field1: String
         }
         
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -375,8 +375,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -556,7 +556,7 @@ class InputTests : XCTestCase {
             let field1: String?
         }
         
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -569,8 +569,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -777,7 +777,7 @@ class InputTests : XCTestCase {
             let input: Echo
         }
 
-        let EchoInputType = try! GraphQLInputObjectType(
+        let EchoInputType = try GraphQLInputObjectType(
             name: "EchoInput",
             fields: [
                 "field1": InputObjectField(
@@ -789,7 +789,7 @@ class InputTests : XCTestCase {
             ]
         )
 
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -805,8 +805,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -912,7 +912,7 @@ class InputTests : XCTestCase {
             let input: Echo
         }
 
-        let EchoInputType = try! GraphQLInputObjectType(
+        let EchoInputType = try GraphQLInputObjectType(
             name: "EchoInput",
             fields: [
                 "field1": InputObjectField(
@@ -924,7 +924,7 @@ class InputTests : XCTestCase {
             ]
         )
 
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -940,8 +940,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -1047,7 +1047,7 @@ class InputTests : XCTestCase {
             let input: Echo
         }
 
-        let EchoInputType = try! GraphQLInputObjectType(
+        let EchoInputType = try GraphQLInputObjectType(
             name: "EchoInput",
             fields: [
                 "field1": InputObjectField(
@@ -1059,7 +1059,7 @@ class InputTests : XCTestCase {
             ]
         )
 
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -1075,8 +1075,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(
@@ -1180,7 +1180,7 @@ class InputTests : XCTestCase {
             let input: Echo
         }
 
-        let EchoInputType = try! GraphQLInputObjectType(
+        let EchoInputType = try GraphQLInputObjectType(
             name: "EchoInput",
             fields: [
                 "field1": InputObjectField(
@@ -1193,7 +1193,7 @@ class InputTests : XCTestCase {
             ]
         )
 
-        let EchoOutputType = try! GraphQLObjectType(
+        let EchoOutputType = try GraphQLObjectType(
             name: "Echo",
             description: "",
             fields: [
@@ -1209,8 +1209,8 @@ class InputTests : XCTestCase {
             }
         )
         
-        let schema = try! GraphQLSchema(
-            query: try! GraphQLObjectType(
+        let schema = try GraphQLSchema(
+            query: try GraphQLObjectType(
                 name: "Query",
                 fields: [
                     "echo": GraphQLField(

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -428,7 +428,8 @@ class SchemaParserTests : XCTestCase {
         )
         
         let result = try parse(source: source)
-        XCTAssertEqual(result.definitions[0] as! ObjectTypeDefinition, expected, "\n\(dump(result.definitions[0]))\n\(dump(expected))\n")
+        let firstDefinition = try XCTUnwrap(result.definitions[0] as? ObjectTypeDefinition)
+        XCTAssertEqual(firstDefinition, expected, "\n\(dump(firstDefinition))\n\(dump(expected))\n")
     }
     
     func testTypeWitMultilinehDescription() throws {

--- a/Tests/GraphQLTests/SubscriptionTests/SubscriptionSchema.swift
+++ b/Tests/GraphQLTests/SubscriptionTests/SubscriptionSchema.swift
@@ -119,8 +119,8 @@ class EmailDb {
     }
     
     /// Returns the default email schema, with standard resolvers.
-    func defaultSchema() -> GraphQLSchema {
-        return emailSchemaWithResolvers(
+    func defaultSchema() throws -> GraphQLSchema {
+        return try emailSchemaWithResolvers(
             resolve: {emailAny, _, _, eventLoopGroup, _ throws -> EventLoopFuture<Any?> in
                 if let email = emailAny as? Email {
                     return eventLoopGroup.next().makeSucceededFuture(EmailEvent(
@@ -155,8 +155,8 @@ class EmailDb {
 }
 
 /// Generates an email schema with the specified resolve and subscribe methods
-func emailSchemaWithResolvers(resolve: GraphQLFieldResolve? = nil, subscribe: GraphQLFieldResolve? = nil) -> GraphQLSchema {
-    return try! GraphQLSchema(
+func emailSchemaWithResolvers(resolve: GraphQLFieldResolve? = nil, subscribe: GraphQLFieldResolve? = nil) throws -> GraphQLSchema {
+    return try GraphQLSchema(
         query: EmailQueryType,
         subscription: try! GraphQLObjectType(
             name: "Subscription",

--- a/Tests/GraphQLTests/SubscriptionTests/SubscriptionTests.swift
+++ b/Tests/GraphQLTests/SubscriptionTests/SubscriptionTests.swift
@@ -15,7 +15,7 @@ class SubscriptionTests : XCTestCase {
     /// This test is not present in graphql-js, but just tests basic functionality.
     func testGraphqlSubscribe() async throws {
         let db = EmailDb()
-        let schema = db.defaultSchema()
+        let schema = try db.defaultSchema()
         let query = """
             subscription ($priority: Int = 0) {
                 importantEmail(priority: $priority) {
@@ -78,7 +78,7 @@ class SubscriptionTests : XCTestCase {
         let db = EmailDb()
         let schema = try GraphQLSchema(
             query: EmailQueryType,
-            subscription: try! GraphQLObjectType(
+            subscription: GraphQLObjectType(
                 name: "Subscription",
                 fields: [
                     "importantEmail": GraphQLField(
@@ -180,7 +180,7 @@ class SubscriptionTests : XCTestCase {
 
         let schema = try GraphQLSchema(
             query: EmailQueryType,
-            subscription: try! GraphQLObjectType(
+            subscription: GraphQLObjectType(
                 name: "Subscription",
                 fields: [
                     "importantEmail": GraphQLField(
@@ -270,7 +270,7 @@ class SubscriptionTests : XCTestCase {
 
     /// 'throws an error if subscribe does not return an iterator'
     func testErrorIfSubscribeIsntIterator() throws {
-        let schema = emailSchemaWithResolvers(
+        let schema = try emailSchemaWithResolvers(
             resolve: {_, _, _, eventLoopGroup, _ throws -> EventLoopFuture<Any?> in
                 return eventLoopGroup.next().makeSucceededFuture(nil)
             },
@@ -323,21 +323,21 @@ class SubscriptionTests : XCTestCase {
         }
 
         // Throwing an error
-        verifyError(schema: emailSchemaWithResolvers(
+        try verifyError(schema: emailSchemaWithResolvers(
             subscribe: {_, _, _, eventLoopGroup, _ throws -> EventLoopFuture<Any?> in
                 throw GraphQLError(message: "test error")
             }
         ))
 
         // Resolving to an error
-        verifyError(schema: emailSchemaWithResolvers(
+        try verifyError(schema: emailSchemaWithResolvers(
             subscribe: {_, _, _, eventLoopGroup, _ throws -> EventLoopFuture<Any?> in
                 return eventLoopGroup.next().makeSucceededFuture(GraphQLError(message: "test error"))
             }
         ))
 
         // Rejecting with an error
-        verifyError(schema: emailSchemaWithResolvers(
+        try verifyError(schema: emailSchemaWithResolvers(
             subscribe: {_, _, _, eventLoopGroup, _ throws -> EventLoopFuture<Any?> in
                 return eventLoopGroup.next().makeFailedFuture(GraphQLError(message: "test error"))
             }
@@ -837,7 +837,7 @@ class SubscriptionTests : XCTestCase {
     func testErrorDuringSubscription() async throws {
         let db = EmailDb()
 
-        let schema = emailSchemaWithResolvers(
+        let schema = try emailSchemaWithResolvers(
             resolve: {emailAny, _, _, eventLoopGroup, _ throws -> EventLoopFuture<Any?> in
                 guard let email = emailAny as? Email else {
                     throw GraphQLError(message:"Source is not Email type: \(type(of: emailAny))")


### PR DESCRIPTION
This MR removes a significant number of `fatalError`s, force-unwraps, force-trys, and force-casts. This is to improve code safety and be more in compliance with the [SSWG Technical Best Practices](https://github.com/swift-server/sswg/blob/main/process/incubation.md#technical-best-practices).

Some force operations remain, but they are mainly where throwing is not possible (top level literals), or in code mostly copied from a specific source. Examples of this include Encoder/Decoders that are based on Foundation's JSON coders, and Visitor based on the graphql-js reference implementation.