### PR TITLE
TypeReference improvements

### DIFF
--- a/Tests/GraphQLTests/TypeTests/GraphQLSchemaTests.swift
+++ b/Tests/GraphQLTests/TypeTests/GraphQLSchemaTests.swift
@@ -157,4 +157,56 @@ class GraphQLSchemaTests: XCTestCase {
             )
         }
     }
+
+    func testAssertSchemaCircularReference() throws {
+        let object1 = try GraphQLObjectType(
+            name: "Object1",
+            fields: [
+                "object2": GraphQLField(
+                    type: GraphQLTypeReference("Object2")
+                ),
+            ]
+        )
+        let object2 = try GraphQLObjectType(
+            name: "Object2",
+            fields: [
+                "object1": GraphQLField(
+                    type: GraphQLTypeReference("Object1")
+                ),
+            ]
+        )
+        let query = try GraphQLObjectType(
+            name: "Query",
+            fields: [
+                "object1": GraphQLField(type: GraphQLTypeReference("Object1")),
+                "object2": GraphQLField(type: GraphQLTypeReference("Object2")),
+            ]
+        )
+
+        let schema = try GraphQLSchema(query: query, types: [object1, object2])
+        for (_, graphQLNamedType) in schema.typeMap {
+            XCTAssertFalse(graphQLNamedType is GraphQLTypeReference)
+        }
+    }
+
+    func testAssertSchemaFailsWhenObjectNotDefined() throws {
+        let object1 = try GraphQLObjectType(
+            name: "Object1",
+            fields: [
+                "object2": GraphQLField(
+                    type: GraphQLTypeReference("Object2")
+                ),
+            ]
+        )
+        let query = try GraphQLObjectType(
+            name: "Query",
+            fields: [
+                "object1": GraphQLField(type: GraphQLTypeReference("Object1")),
+            ]
+        )
+
+        XCTAssertThrowsError(
+            _ = try GraphQLSchema(query: query, types: [object1])
+        )
+    }
 }


### PR DESCRIPTION
This PR adds enhances TypeReference handling in the following ways:

1. Changes logic to ensure that TypeReferences are replaced during typeMapReduction
2. Adds logic to ensure that all TypeReferences in instantiated Schemas have been replaced by the actual types. In the case where they are not, the schema initalizer throws an error.

Tests are added too