### PR TITLE
Making Visitor public

### DIFF
--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -1,4 +1,4 @@
-let QueryDocumentKeys: [Kind: [String]] = [
+public let QueryDocumentKeys: [Kind: [String]] = [
     .name: [],
 
     .document: ["definitions"],
@@ -80,7 +80,7 @@ let QueryDocumentKeys: [Kind: [String]] = [
  *     ))
  */
 @discardableResult
-func visit(root: Node, visitor: Visitor, keyMap: [Kind: [String]] = [:]) -> Node {
+public func visit(root: Node, visitor: Visitor, keyMap: [Kind: [String]] = [:]) -> Node {
     let visitorKeys = keyMap.isEmpty ? QueryDocumentKeys : keyMap
 
     var stack: Stack?


### PR DESCRIPTION
In the project I am working on I needed a way to parse an incoming GraphQL request. However my code is about understanding the incoming request, not executing it. So I needed to be able to parse a request and retrieve the AST which I could then look at. 

To this end I needed the parse functions to be accessible. This PR makes them public so I can parse the request and retrieve the AST. 