### PR TITLE
Making visit(...) public.

### DIFF
--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -1,4 +1,4 @@
-let QueryDocumentKeys: [Kind: [String]] = [
+public let QueryDocumentKeys: [Kind: [String]] = [
     .name: [],
 
     .document: ["definitions"],
@@ -80,7 +80,7 @@ let QueryDocumentKeys: [Kind: [String]] = [
  *     ))
  */
 @discardableResult
-func visit(root: Node, visitor: Visitor, keyMap: [Kind: [String]] = [:]) -> Node {
+public func visit(root: Node, visitor: Visitor, keyMap: [Kind: [String]] = [:]) -> Node {
     let visitorKeys = keyMap.isEmpty ? QueryDocumentKeys : keyMap
 
     var stack: Stack?

--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -1,4 +1,4 @@
-public let QueryDocumentKeys: [Kind: [String]] = [
+let QueryDocumentKeys: [Kind: [String]] = [
     .name: [],
 
     .document: ["definitions"],


### PR DESCRIPTION
In my code I needed a way to parse an incoming GraphQL request and retrieve the AST. I do not need to execute it. 

This PR makes the `visit(...)` function public so that I can call it to parse the incoming requests and analyse the results in it's closures.