### PR TITLE
Optimizes parsing of large non-UTF8 queries

### DIFF
--- a/Sources/GraphQL/Language/Source.swift
+++ b/Sources/GraphQL/Language/Source.swift
@@ -3,13 +3,19 @@
  * but is mostly useful for clients who store GraphQL documents in
  * source files; for example, if the GraphQL input is in a file Foo.graphql,
  * it might be useful for name to be "Foo.graphql".
+ *
+ * Note that since Source parsing is heavily UTF8 dependent, the body
+ * is converted into contiguous UTF8 bytes if necessary for optimal performance.
  */
 public struct Source {
     public let body: String
     public let name: String
 
     public init(body: String, name: String = "GraphQL") {
-        self.body = body
+        var utf8Body = body
+        utf8Body.makeContiguousUTF8()
+
+        self.body = utf8Body
         self.name = name
     }
 }


### PR DESCRIPTION
While this doesn't impact UTF8 strings built up in Swift, Strings decoded from data (like through Vapor, for example) may not be marked as UTF8, which makes the lexer UTF8 conversions very expensive. In evaluation of 450kb requests, performance improved from 27min to 5sec with this adjustment.