### PR TITLE
Extend Schema Support

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -213,6 +213,7 @@ extension EnumTypeDefinition: Node {}
 extension EnumValueDefinition: Node {}
 extension InputObjectTypeDefinition: Node {}
 extension TypeExtensionDefinition: Node {}
+extension SchemaExtensionDefinition: Node {}
 extension DirectiveDefinition: Node {}
 
 public final class Name {
@@ -1099,6 +1100,7 @@ extension NonNullType: Equatable {
 public protocol TypeSystemDefinition: Definition {}
 extension SchemaDefinition: TypeSystemDefinition {}
 extension TypeExtensionDefinition: TypeSystemDefinition {}
+extension SchemaExtensionDefinition: TypeSystemDefinition {}
 extension DirectiveDefinition: TypeSystemDefinition {}
 
 public func == (lhs: TypeSystemDefinition, rhs: TypeSystemDefinition) -> Bool {
@@ -1117,6 +1119,10 @@ public func == (lhs: TypeSystemDefinition, rhs: TypeSystemDefinition) -> Bool {
         }
     case let l as TypeDefinition:
         if let r = rhs as? TypeDefinition {
+            return l == r
+        }
+    case let l as SchemaExtensionDefinition:
+        if let r = rhs as? SchemaExtensionDefinition {
             return l == r
         }
     default:
@@ -1539,6 +1545,23 @@ public final class TypeExtensionDefinition {
 
 extension TypeExtensionDefinition: Equatable {
     public static func == (lhs: TypeExtensionDefinition, rhs: TypeExtensionDefinition) -> Bool {
+        return lhs.definition == rhs.definition
+    }
+}
+
+public final class SchemaExtensionDefinition {
+    public let kind: Kind = .schemaExtensionDefinition
+    public let loc: Location?
+    public let definition: SchemaDefinition
+
+    init(loc: Location? = nil, definition: SchemaDefinition) {
+        self.loc = loc
+        self.definition = definition
+    }
+}
+
+extension SchemaExtensionDefinition: Equatable {
+    public static func == (lhs: SchemaExtensionDefinition, rhs: SchemaExtensionDefinition) -> Bool {
         return lhs.definition == rhs.definition
     }
 }

--- a/Sources/GraphQL/Language/Kinds.swift
+++ b/Sources/GraphQL/Language/Kinds.swift
@@ -36,4 +36,5 @@ public enum Kind {
     case inputObjectTypeDefinition
     case typeExtensionDefinition
     case directiveDefinition
+    case schemaExtensionDefinition
 }

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -111,6 +111,64 @@ class SchemaParserTests: XCTestCase {
         XCTAssert(result == expected)
     }
 
+    func testSchemeExtension() throws {
+        // Based on Apollo Federation example schema: https://github.com/apollographql/apollo-federation-subgraph-compatibility/blob/main/COMPATIBILITY.md#products-schema-to-be-implemented-by-library-maintainers
+        let source =
+            """
+            extend schema
+              @link(
+                url: "https://specs.apollo.dev/federation/v2.0",
+                import: [
+                  "@extends",
+                  "@external",
+                  "@key",
+                  "@inaccessible",
+                  "@override",
+                  "@provides",
+                  "@requires",
+                  "@shareable",
+                  "@tag"
+                ]
+              )
+            """
+
+        let expected = Document(
+            definitions: [
+                SchemaExtensionDefinition(
+                    definition: SchemaDefinition(
+                        directives: [
+                            Directive(
+                                name: nameNode("link"),
+                                arguments: [
+                                    Argument(
+                                        name: nameNode("url"),
+                                        value: StringValue(
+                                            value: "https://specs.apollo.dev/federation/v2.0",
+                                            block: false
+                                        )
+                                    ),
+                                    Argument(
+                                        name: nameNode("import"),
+                                        value: ListValue(values: [
+                                            StringValue(value: "@extends", block: false),
+                                            StringValue(value: "@external", block: false),
+                                            StringValue(value: "@key", block: false),
+                                            StringValue(value: "@inaccessible", block: false),
+                                            StringValue(value: "@override", block: false),
+                                            StringValue(value: "@provides", block: false),
+                                            StringValue(value: "@requires", block: false),
+                                            StringValue(value: "@shareable", block: false),
+                                            StringValue(value: "@tag", block: false),
+                                        ]))
+                                ])
+                        ],
+                        operationTypes: []))
+            ])
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
     func testSimpleNonNullType() throws {
         let source = "type Hello { world: String! }"
 


### PR DESCRIPTION
This PR adds support for `extend Schema` syntax used with Apollo Federation. 