### PR TITLE
fix: correctly handle missing GraphQLError location/path on decode

### DIFF
--- a/Sources/GraphQL/Error/GraphQLError.swift
+++ b/Sources/GraphQL/Error/GraphQLError.swift
@@ -118,7 +118,7 @@ public struct GraphQLError: Error, Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         message = try container.decode(String.self, forKey: .message)
-        locations = try container.decode([SourceLocation]?.self, forKey: .locations) ?? []
+        locations = (try? container.decode([SourceLocation]?.self, forKey: .locations)) ?? []
         path = try container.decode(IndexPath.self, forKey: .path)
     }
 
@@ -166,7 +166,7 @@ public struct IndexPath: Codable {
 
     public init(from decoder: Decoder) throws {
         var container = try decoder.unkeyedContainer()
-        elements = try container.decode([IndexPathValue].self)
+        elements = (try? container.decode([IndexPathValue].self)) ?? []
     }
 
     public func encode(to encoder: Encoder) throws {


### PR DESCRIPTION
Small fix for the `GraphQLError` decoder that allows correctly decoding an error with a missing `location` or `path` field by defaulting to empty.