### PR TITLE
Update Schema Kitchen Sink Parsing + Tests

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -1684,19 +1684,22 @@ public final class DirectiveDefinition {
     public let name: Name
     public let arguments: [InputValueDefinition]
     public let locations: [Name]
+    public let repeatable: Bool
 
     init(
         loc: Location? = nil,
         description: StringValue? = nil,
         name: Name,
         arguments: [InputValueDefinition] = [],
-        locations: [Name]
+        locations: [Name],
+        repeatable: Bool = false
     ) {
         self.loc = loc
         self.name = name
         self.description = description
         self.arguments = arguments
         self.locations = locations
+        self.repeatable = repeatable
     }
 }
 

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -1604,7 +1604,10 @@ public final class InterfaceExtensionDefinition {
 }
 
 extension InterfaceExtensionDefinition: Equatable {
-    public static func == (lhs: InterfaceExtensionDefinition, rhs: InterfaceExtensionDefinition) -> Bool {
+    public static func == (
+        lhs: InterfaceExtensionDefinition,
+        rhs: InterfaceExtensionDefinition
+    ) -> Bool {
         return lhs.definition == rhs.definition
     }
 }
@@ -1672,7 +1675,10 @@ public final class InputObjectExtensionDefinition {
 }
 
 extension InputObjectExtensionDefinition: Equatable {
-    public static func == (lhs: InputObjectExtensionDefinition, rhs: InputObjectExtensionDefinition) -> Bool {
+    public static func == (
+        lhs: InputObjectExtensionDefinition,
+        rhs: InputObjectExtensionDefinition
+    ) -> Bool {
         return lhs.definition == rhs.definition
     }
 }

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -39,6 +39,7 @@ public final class Token {
         case eof = "<EOF>"
         case bang = "!"
         case dollar = "$"
+        case amp = "&"
         case openingParenthesis = "("
         case closingParenthesis = ")"
         case spread = "..."

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -1103,6 +1103,11 @@ extension SchemaDefinition: TypeSystemDefinition {}
 extension TypeExtensionDefinition: TypeSystemDefinition {}
 extension SchemaExtensionDefinition: TypeSystemDefinition {}
 extension DirectiveDefinition: TypeSystemDefinition {}
+extension InterfaceExtensionDefinition: TypeSystemDefinition {}
+extension ScalarExtensionDefinition: TypeSystemDefinition {}
+extension UnionExtensionDefinition: TypeSystemDefinition {}
+extension EnumExtensionDefinition: TypeSystemDefinition {}
+extension InputObjectExtensionDefinition: TypeSystemDefinition {}
 
 public func == (lhs: TypeSystemDefinition, rhs: TypeSystemDefinition) -> Bool {
     switch lhs {
@@ -1124,6 +1129,26 @@ public func == (lhs: TypeSystemDefinition, rhs: TypeSystemDefinition) -> Bool {
         }
     case let l as SchemaExtensionDefinition:
         if let r = rhs as? SchemaExtensionDefinition {
+            return l == r
+        }
+    case let l as InterfaceExtensionDefinition:
+        if let r = rhs as? InterfaceExtensionDefinition {
+            return l == r
+        }
+    case let l as ScalarExtensionDefinition:
+        if let r = rhs as? ScalarExtensionDefinition {
+            return l == r
+        }
+    case let l as UnionExtensionDefinition:
+        if let r = rhs as? UnionExtensionDefinition {
+            return l == r
+        }
+    case let l as EnumExtensionDefinition:
+        if let r = rhs as? EnumExtensionDefinition {
+            return l == r
+        }
+    case let l as InputObjectExtensionDefinition:
+        if let r = rhs as? InputObjectExtensionDefinition {
             return l == r
         }
     default:
@@ -1563,6 +1588,91 @@ public final class SchemaExtensionDefinition {
 
 extension SchemaExtensionDefinition: Equatable {
     public static func == (lhs: SchemaExtensionDefinition, rhs: SchemaExtensionDefinition) -> Bool {
+        return lhs.definition == rhs.definition
+    }
+}
+
+public final class InterfaceExtensionDefinition {
+    public let kind: Kind = .interfaceExtensionDefinition
+    public let loc: Location?
+    public let definition: InterfaceTypeDefinition
+
+    init(loc: Location? = nil, definition: InterfaceTypeDefinition) {
+        self.loc = loc
+        self.definition = definition
+    }
+}
+
+extension InterfaceExtensionDefinition: Equatable {
+    public static func == (lhs: InterfaceExtensionDefinition, rhs: InterfaceExtensionDefinition) -> Bool {
+        return lhs.definition == rhs.definition
+    }
+}
+
+public final class ScalarExtensionDefinition {
+    public let kind: Kind = .scalarExtensionDefinition
+    public let loc: Location?
+    public let definition: ScalarTypeDefinition
+
+    init(loc: Location? = nil, definition: ScalarTypeDefinition) {
+        self.loc = loc
+        self.definition = definition
+    }
+}
+
+extension ScalarExtensionDefinition: Equatable {
+    public static func == (lhs: ScalarExtensionDefinition, rhs: ScalarExtensionDefinition) -> Bool {
+        return lhs.definition == rhs.definition
+    }
+}
+
+public final class UnionExtensionDefinition {
+    public let kind: Kind = .unionExtensionDefinition
+    public let loc: Location?
+    public let definition: UnionTypeDefinition
+
+    init(loc: Location? = nil, definition: UnionTypeDefinition) {
+        self.loc = loc
+        self.definition = definition
+    }
+}
+
+extension UnionExtensionDefinition: Equatable {
+    public static func == (lhs: UnionExtensionDefinition, rhs: UnionExtensionDefinition) -> Bool {
+        return lhs.definition == rhs.definition
+    }
+}
+
+public final class EnumExtensionDefinition {
+    public let kind: Kind = .enumExtensionDefinition
+    public let loc: Location?
+    public let definition: EnumTypeDefinition
+
+    init(loc: Location? = nil, definition: EnumTypeDefinition) {
+        self.loc = loc
+        self.definition = definition
+    }
+}
+
+extension EnumExtensionDefinition: Equatable {
+    public static func == (lhs: EnumExtensionDefinition, rhs: EnumExtensionDefinition) -> Bool {
+        return lhs.definition == rhs.definition
+    }
+}
+
+public final class InputObjectExtensionDefinition {
+    public let kind: Kind = .inputObjectExtensionDefinition
+    public let loc: Location?
+    public let definition: InputObjectTypeDefinition
+
+    init(loc: Location? = nil, definition: InputObjectTypeDefinition) {
+        self.loc = loc
+        self.definition = definition
+    }
+}
+
+extension InputObjectExtensionDefinition: Equatable {
+    public static func == (lhs: InputObjectExtensionDefinition, rhs: InputObjectExtensionDefinition) -> Bool {
         return lhs.definition == rhs.definition
     }
 }

--- a/Sources/GraphQL/Language/Kinds.swift
+++ b/Sources/GraphQL/Language/Kinds.swift
@@ -37,4 +37,9 @@ public enum Kind {
     case typeExtensionDefinition
     case directiveDefinition
     case schemaExtensionDefinition
+    case interfaceExtensionDefinition
+    case scalarExtensionDefinition
+    case unionExtensionDefinition
+    case enumExtensionDefinition
+    case inputObjectExtensionDefinition
 }

--- a/Sources/GraphQL/Language/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer.swift
@@ -244,6 +244,16 @@ func readToken(lexer: Lexer, prev: Token) throws -> Token {
             column: col,
             prev: prev
         )
+    // &
+    case 38:
+        return Token(
+            kind: .amp,
+            start: position,
+            end: position + 1,
+            line: line,
+            column: col,
+            prev: prev
+        )
     // (
     case 40:
         return Token(

--- a/Sources/GraphQL/Language/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer.swift
@@ -47,17 +47,17 @@ func advanceLexer(lexer: Lexer) throws -> Token {
 }
 
 /**
-  * Returns a non-empty list of parse nodes, determined by the parseFn.
-  * This list may begin with a lex token of delimiterKind followed by items separated by lex tokens of tokenKind.
-  * Advances the parser to the next lex token after last item in the list.
-  */
+ * Returns a non-empty list of parse nodes, determined by the parseFn.
+ * This list may begin with a lex token of delimiterKind followed by items separated by lex tokens of tokenKind.
+ * Advances the parser to the next lex token after last item in the list.
+ */
 func delimitedMany<T>(lexer: Lexer, kind: Token.Kind, parseFn: (Lexer) throws -> T) throws -> [T] {
     _ = try expectOptional(lexer: lexer, kind: kind)
 
     var nodes: [T] = []
     repeat {
         try nodes.append(parseFn(lexer))
-    } while (try expectOptional(lexer: lexer, kind: kind) != nil)
+    } while try expectOptional(lexer: lexer, kind: kind) != nil
 
     return nodes
 }

--- a/Sources/GraphQL/Language/Lexer.swift
+++ b/Sources/GraphQL/Language/Lexer.swift
@@ -47,6 +47,22 @@ func advanceLexer(lexer: Lexer) throws -> Token {
 }
 
 /**
+  * Returns a non-empty list of parse nodes, determined by the parseFn.
+  * This list may begin with a lex token of delimiterKind followed by items separated by lex tokens of tokenKind.
+  * Advances the parser to the next lex token after last item in the list.
+  */
+func delimitedMany<T>(lexer: Lexer, kind: Token.Kind, parseFn: (Lexer) throws -> T) throws -> [T] {
+    _ = try expectOptional(lexer: lexer, kind: kind)
+
+    var nodes: [T] = []
+    repeat {
+        try nodes.append(parseFn(lexer))
+    } while (try expectOptional(lexer: lexer, kind: kind) != nil)
+
+    return nodes
+}
+
+/**
  * The return type of createLexer.
  */
 final class Lexer {

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -1010,11 +1010,16 @@ func parseExtensionDefinition(lexer: Lexer) throws -> TypeSystemDefinition {
     switch token.value {
     case "type": return try parseTypeExtensionDefinition(lexer: lexer)
     case "schema": return try parseSchemaExtensionDefinition(lexer: lexer)
+    case "interface": return try parseInterfaceExtensionDefinition(lexer: lexer)
+    case "scalar": return try parseScalarExtensionDefinition(lexer: lexer)
+    case "union": return try parseUnionExtensionDefinition(lexer: lexer)
+    case "enum": return try parseEnumExtensionDefinition(lexer: lexer)
+    case "input": return try parseInputObjectExtensionDefinition(lexer: lexer)
     default:
         throw syntaxError(
             source: lexer.source,
             position: token.start,
-            description: "expected schema or type after extend"
+            description: "expected schema or type or interface or scalar or union or enum or input after extend"
         )
     }
 }
@@ -1049,6 +1054,71 @@ func parseSchemaExtensionDefinition(lexer: Lexer) throws -> SchemaExtensionDefin
             directives: directives,
             operationTypes: []
         )
+    )
+}
+
+/**
+ * InterfaceExtensionDefinition: extend InterfaceTypeDefinition
+ */
+func parseInterfaceExtensionDefinition(lexer: Lexer) throws -> InterfaceExtensionDefinition {
+    let start = lexer.token
+    try expectKeyword(lexer: lexer, value: "extend")
+    let interfaceDefinition = try parseInterfaceTypeDefinition(lexer: lexer)
+    return InterfaceExtensionDefinition(
+        loc: loc(lexer: lexer, startToken: start),
+        definition: interfaceDefinition
+    )
+}
+
+/**
+ * ScalarExtensionDefinition: extend InterfaceTypeDefinition
+ */
+func parseScalarExtensionDefinition(lexer: Lexer) throws -> ScalarExtensionDefinition {
+    let start = lexer.token
+    try expectKeyword(lexer: lexer, value: "extend")
+    let scalarDefinition = try parseScalarTypeDefinition(lexer: lexer)
+    return ScalarExtensionDefinition(
+        loc: loc(lexer: lexer, startToken: start),
+        definition: scalarDefinition
+    )
+}
+
+/**
+ * UnionExtensionDefinition: extend UnionTypeDefinition
+ */
+func parseUnionExtensionDefinition(lexer: Lexer) throws -> UnionExtensionDefinition {
+    let start = lexer.token
+    try expectKeyword(lexer: lexer, value: "extend")
+    let definition = try parseUnionTypeDefinition(lexer: lexer)
+    return UnionExtensionDefinition(
+        loc: loc(lexer: lexer, startToken: start),
+        definition: definition
+    )
+}
+
+/**
+ * EnumExtensionDefinition: extend EnumTypeDefinition
+ */
+func parseEnumExtensionDefinition(lexer: Lexer) throws -> EnumExtensionDefinition {
+    let start = lexer.token
+    try expectKeyword(lexer: lexer, value: "extend")
+    let definition = try parseEnumTypeDefinition(lexer: lexer)
+    return EnumExtensionDefinition(
+        loc: loc(lexer: lexer, startToken: start),
+        definition: definition
+    )
+}
+
+/**
+ * InputObjectExtensionDefinition: extend InputObjectTypeDefinition
+ */
+func parseInputObjectExtensionDefinition(lexer: Lexer) throws -> InputObjectExtensionDefinition {
+    let start = lexer.token
+    try expectKeyword(lexer: lexer, value: "extend")
+    let definition = try parseInputObjectTypeDefinition(lexer: lexer)
+    return InputObjectExtensionDefinition(
+        loc: loc(lexer: lexer, startToken: start),
+        definition: definition
     )
 }
 

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -822,7 +822,8 @@ func parseImplementsInterfaces(lexer: Lexer) throws -> [NamedType] {
         try expectOptional(lexer: lexer, kind: .amp)
         repeat {
             types.append(try parseNamedType(lexer: lexer))
-        } while try expectOptional(lexer: lexer, kind: .amp) != nil || peek(lexer: lexer, kind: .name)
+        } while try expectOptional(lexer: lexer, kind: .amp) != nil ||
+            peek(lexer: lexer, kind: .name)
     }
 
     return types
@@ -942,7 +943,7 @@ func parseUnionTypeDefinition(lexer: Lexer) throws -> UnionTypeDefinition {
     try expectKeyword(lexer: lexer, value: "union")
     let name = try parseName(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    
+
     do {
         try expect(lexer: lexer, kind: .equals)
         let types = try parseUnionMembers(lexer: lexer)

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -796,7 +796,9 @@ func parseObjectTypeDefinition(lexer: Lexer) throws -> ObjectTypeDefinition {
 }
 
 /**
- * ImplementsInterfaces : implements NamedType+
+ * ImplementsInterfaces :
+ *  - implements &? NamedType
+ *  - ImplementsInterfaces & NamedType
  */
 func parseImplementsInterfaces(lexer: Lexer) throws -> [NamedType] {
     var types: [NamedType] = []
@@ -804,9 +806,10 @@ func parseImplementsInterfaces(lexer: Lexer) throws -> [NamedType] {
     if lexer.token.value == "implements" {
         try lexer.advance()
 
+        try expectOptional(lexer: lexer, kind: .amp)
         repeat {
             types.append(try parseNamedType(lexer: lexer))
-        } while peek(lexer: lexer, kind: .name)
+        } while try expectOptional(lexer: lexer, kind: .amp) != nil || peek(lexer: lexer, kind: .name)
     }
 
     return types
@@ -1146,6 +1149,20 @@ func expect(lexer: Lexer, kind: Token.Kind) throws -> Token {
 
     try lexer.advance()
     return token
+}
+
+/**
+ * If the next token is of the given kind, return that token after advancing
+ * the lexer. Otherwise, do not change the parser state and return nil.
+ */
+@discardableResult
+func expectOptional(lexer: Lexer, kind: Token.Kind) throws -> Token? {
+    let token = lexer.token
+    if token.kind == kind {
+        try lexer.advance()
+        return token
+    }
+    return nil
 }
 
 /**

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -780,7 +780,12 @@ func parseObjectTypeDefinition(lexer: Lexer) throws -> ObjectTypeDefinition {
     let name = try parseName(lexer: lexer)
     let interfaces = try parseImplementsInterfaces(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let fields = try optionalMany(lexer: lexer, openKind: .openingBrace, closeKind: .closingBrace, parse: parseFieldDefinition)
+    let fields = try optionalMany(
+        lexer: lexer,
+        openKind: .openingBrace,
+        closeKind: .closingBrace,
+        parse: parseFieldDefinition
+    )
     return ObjectTypeDefinition(
         loc: loc(lexer: lexer, startToken: start),
         description: description,
@@ -798,8 +803,8 @@ func parseObjectTypeDefinition(lexer: Lexer) throws -> ObjectTypeDefinition {
  */
 func parseImplementsInterfaces(lexer: Lexer) throws -> [NamedType] {
     try expectOptionalKeyword(lexer: lexer, value: "implements")
-    ? delimitedMany(lexer: lexer, kind: .amp, parseFn: parseNamedType)
-    : []
+        ? delimitedMany(lexer: lexer, kind: .amp, parseFn: parseNamedType)
+        : []
 }
 
 /**
@@ -877,7 +882,12 @@ func parseInterfaceTypeDefinition(lexer: Lexer) throws -> InterfaceTypeDefinitio
     let name = try parseName(lexer: lexer)
     let interfaces = try parseImplementsInterfaces(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let fields = try optionalMany(lexer: lexer, openKind: .openingBrace, closeKind: .closingBrace, parse: parseFieldDefinition)
+    let fields = try optionalMany(
+        lexer: lexer,
+        openKind: .openingBrace,
+        closeKind: .closingBrace,
+        parse: parseFieldDefinition
+    )
     return InterfaceTypeDefinition(
         loc: loc(lexer: lexer, startToken: start),
         description: description,
@@ -915,8 +925,8 @@ func parseUnionTypeDefinition(lexer: Lexer) throws -> UnionTypeDefinition {
  */
 func parseUnionMembers(lexer: Lexer) throws -> [NamedType] {
     try expectOptional(lexer: lexer, kind: .equals) != nil
-    ? delimitedMany(lexer: lexer, kind: .pipe, parseFn: parseNamedType)
-    : []
+        ? delimitedMany(lexer: lexer, kind: .pipe, parseFn: parseNamedType)
+        : []
 }
 
 /**
@@ -930,7 +940,12 @@ func parseEnumTypeDefinition(lexer: Lexer) throws -> EnumTypeDefinition {
     try expectKeyword(lexer: lexer, value: "enum")
     let name = try parseName(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let values = try optionalMany(lexer: lexer, openKind: .openingBrace, closeKind: .closingBrace, parse: parseEnumValueDefinition)
+    let values = try optionalMany(
+        lexer: lexer,
+        openKind: .openingBrace,
+        closeKind: .closingBrace,
+        parse: parseEnumValueDefinition
+    )
     return EnumTypeDefinition(
         loc: loc(lexer: lexer, startToken: start),
         description: description,
@@ -969,7 +984,12 @@ func parseInputObjectTypeDefinition(lexer: Lexer) throws -> InputObjectTypeDefin
     try expectKeyword(lexer: lexer, value: "input")
     let name = try parseName(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let fields = try optionalMany(lexer: lexer, openKind: .openingBrace, closeKind: .closingBrace, parse: parseInputValueDef)
+    let fields = try optionalMany(
+        lexer: lexer,
+        openKind: .openingBrace,
+        closeKind: .closingBrace,
+        parse: parseInputValueDef
+    )
     return InputObjectTypeDefinition(
         loc: loc(lexer: lexer, startToken: start),
         description: description,
@@ -1228,13 +1248,13 @@ func expectKeyword(lexer: Lexer, value: String) throws -> Token {
 }
 
 /**
-* If the next token is a given keyword, return "true" after advancing the lexer.
-* Otherwise, do not change the parser state and return "false".
-*/
+ * If the next token is a given keyword, return "true" after advancing the lexer.
+ * Otherwise, do not change the parser state and return "false".
+ */
 @discardableResult
 func expectOptionalKeyword(lexer: Lexer, value: String) throws -> Bool {
     let token = lexer.token
-    guard token.kind == .name && token.value == value else {
+    guard token.kind == .name, token.value == value else {
         return false
     }
     try lexer.advance()
@@ -1277,12 +1297,17 @@ func any<T>(
 }
 
 /**
-* Returns a list of parse nodes, determined by the parseFn.
-* It can be empty only if open token is missing otherwise it will always return non-empty list
-* that begins with a lex token of openKind and ends with a lex token of closeKind.
-* Advances the parser to the next lex token after the closing token.
-*/
-func optionalMany<T>(lexer: Lexer, openKind: Token.Kind, closeKind: Token.Kind, parse: (Lexer) throws -> T) throws -> [T] {
+ * Returns a list of parse nodes, determined by the parseFn.
+ * It can be empty only if open token is missing otherwise it will always return non-empty list
+ * that begins with a lex token of openKind and ends with a lex token of closeKind.
+ * Advances the parser to the next lex token after the closing token.
+ */
+func optionalMany<T>(
+    lexer: Lexer,
+    openKind: Token.Kind,
+    closeKind: Token.Kind,
+    parse: (Lexer) throws -> T
+) throws -> [T] {
     guard try expectOptional(lexer: lexer, kind: openKind) != nil else {
         return []
     }

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -771,6 +771,7 @@ func parseScalarTypeDefinition(lexer: Lexer) throws -> ScalarTypeDefinition {
 /**
  * ObjectTypeDefinition :
  *   - type Name ImplementsInterfaces? Directives? { FieldDefinition+ }
+ *   - type Name ImplementsInterfaces? Directives?
  */
 func parseObjectTypeDefinition(lexer: Lexer) throws -> ObjectTypeDefinition {
     let start = lexer.token
@@ -779,20 +780,32 @@ func parseObjectTypeDefinition(lexer: Lexer) throws -> ObjectTypeDefinition {
     let name = try parseName(lexer: lexer)
     let interfaces = try parseImplementsInterfaces(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let fields = try any(
-        lexer: lexer,
-        openKind: .openingBrace,
-        closeKind: .closingBrace,
-        parse: parseFieldDefinition
-    )
-    return ObjectTypeDefinition(
-        loc: loc(lexer: lexer, startToken: start),
-        description: description,
-        name: name,
-        interfaces: interfaces,
-        directives: directives,
-        fields: fields
-    )
+
+    do {
+        let fields = try any(
+            lexer: lexer,
+            openKind: .openingBrace,
+            closeKind: .closingBrace,
+            parse: parseFieldDefinition
+        )
+        return ObjectTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            interfaces: interfaces,
+            directives: directives,
+            fields: fields
+        )
+    } catch {
+        return ObjectTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            interfaces: interfaces,
+            directives: directives,
+            fields: []
+        )
+    }
 }
 
 /**
@@ -879,7 +892,9 @@ func parseInputValueDef(lexer: Lexer) throws -> InputValueDefinition {
 }
 
 /**
- * InterfaceTypeDefinition : interface Name Directives? { FieldDefinition+ }
+ * InterfaceTypeDefinition :
+ * - interface Name Directives? { FieldDefinition+ }
+ * - interface Name Directives?
  */
 func parseInterfaceTypeDefinition(lexer: Lexer) throws -> InterfaceTypeDefinition {
     let start = lexer.token
@@ -888,24 +903,38 @@ func parseInterfaceTypeDefinition(lexer: Lexer) throws -> InterfaceTypeDefinitio
     let name = try parseName(lexer: lexer)
     let interfaces = try parseImplementsInterfaces(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let fields = try any(
-        lexer: lexer,
-        openKind: .openingBrace,
-        closeKind: .closingBrace,
-        parse: parseFieldDefinition
-    )
-    return InterfaceTypeDefinition(
-        loc: loc(lexer: lexer, startToken: start),
-        description: description,
-        name: name,
-        interfaces: interfaces,
-        directives: directives,
-        fields: fields
-    )
+
+    do {
+        let fields = try any(
+            lexer: lexer,
+            openKind: .openingBrace,
+            closeKind: .closingBrace,
+            parse: parseFieldDefinition
+        )
+        return InterfaceTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            interfaces: interfaces,
+            directives: directives,
+            fields: fields
+        )
+    } catch {
+        return InterfaceTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            interfaces: interfaces,
+            directives: directives,
+            fields: []
+        )
+    }
 }
 
 /**
- * UnionTypeDefinition : union Name Directives? = UnionMembers
+ * UnionTypeDefinition :
+ * - union Name Directives? = UnionMembers
+ * - union Name Directives?
  */
 func parseUnionTypeDefinition(lexer: Lexer) throws -> UnionTypeDefinition {
     let start = lexer.token
@@ -913,15 +942,26 @@ func parseUnionTypeDefinition(lexer: Lexer) throws -> UnionTypeDefinition {
     try expectKeyword(lexer: lexer, value: "union")
     let name = try parseName(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    try expect(lexer: lexer, kind: .equals)
-    let types = try parseUnionMembers(lexer: lexer)
-    return UnionTypeDefinition(
-        loc: loc(lexer: lexer, startToken: start),
-        description: description,
-        name: name,
-        directives: directives,
-        types: types
-    )
+    
+    do {
+        try expect(lexer: lexer, kind: .equals)
+        let types = try parseUnionMembers(lexer: lexer)
+        return UnionTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            directives: directives,
+            types: types
+        )
+    } catch {
+        return UnionTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            directives: directives,
+            types: []
+        )
+    }
 }
 
 /**
@@ -940,7 +980,9 @@ func parseUnionMembers(lexer: Lexer) throws -> [NamedType] {
 }
 
 /**
- * EnumTypeDefinition : enum Name Directives? { EnumValueDefinition+ }
+ * EnumTypeDefinition :
+ * - enum Name Directives? { EnumValueDefinition+ }
+ * - enum Name Directives?
  */
 func parseEnumTypeDefinition(lexer: Lexer) throws -> EnumTypeDefinition {
     let start = lexer.token
@@ -948,19 +990,30 @@ func parseEnumTypeDefinition(lexer: Lexer) throws -> EnumTypeDefinition {
     try expectKeyword(lexer: lexer, value: "enum")
     let name = try parseName(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let values = try many(
-        lexer: lexer,
-        openKind: .openingBrace,
-        closeKind: .closingBrace,
-        parse: parseEnumValueDefinition
-    )
-    return EnumTypeDefinition(
-        loc: loc(lexer: lexer, startToken: start),
-        description: description,
-        name: name,
-        directives: directives,
-        values: values
-    )
+
+    do {
+        let values = try many(
+            lexer: lexer,
+            openKind: .openingBrace,
+            closeKind: .closingBrace,
+            parse: parseEnumValueDefinition
+        )
+        return EnumTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            directives: directives,
+            values: values
+        )
+    } catch {
+        return EnumTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            directives: directives,
+            values: []
+        )
+    }
 }
 
 /**
@@ -982,7 +1035,9 @@ func parseEnumValueDefinition(lexer: Lexer) throws -> EnumValueDefinition {
 }
 
 /**
- * InputObjectTypeDefinition : input Name Directives? { InputValueDefinition+ }
+ * InputObjectTypeDefinition :
+ * - input Name Directives? { InputValueDefinition+ }
+ * - input Name Directives?
  */
 func parseInputObjectTypeDefinition(lexer: Lexer) throws -> InputObjectTypeDefinition {
     let start = lexer.token
@@ -990,19 +1045,30 @@ func parseInputObjectTypeDefinition(lexer: Lexer) throws -> InputObjectTypeDefin
     try expectKeyword(lexer: lexer, value: "input")
     let name = try parseName(lexer: lexer)
     let directives = try parseDirectives(lexer: lexer)
-    let fields = try any(
-        lexer: lexer,
-        openKind: .openingBrace,
-        closeKind: .closingBrace,
-        parse: parseInputValueDef
-    )
-    return InputObjectTypeDefinition(
-        loc: loc(lexer: lexer, startToken: start),
-        description: description,
-        name: name,
-        directives: directives,
-        fields: fields
-    )
+
+    do {
+        let fields = try any(
+            lexer: lexer,
+            openKind: .openingBrace,
+            closeKind: .closingBrace,
+            parse: parseInputValueDef
+        )
+        return InputObjectTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            directives: directives,
+            fields: fields
+        )
+    } catch {
+        return InputObjectTypeDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            directives: directives,
+            fields: []
+        )
+    }
 }
 
 func parseExtensionDefinition(lexer: Lexer) throws -> TypeSystemDefinition {

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -968,10 +968,12 @@ func parseUnionTypeDefinition(lexer: Lexer) throws -> UnionTypeDefinition {
  * UnionMembers :
  *   - NamedType
  *   - UnionMembers | NamedType
+ *   - | UnionMembers | NamedType
  */
 func parseUnionMembers(lexer: Lexer) throws -> [NamedType] {
     var members: [NamedType] = []
 
+    try expectOptional(lexer: lexer, kind: .pipe)
     repeat {
         members.append(try parseNamedType(lexer: lexer))
     } while try skip(lexer: lexer, kind: .pipe)
@@ -1203,6 +1205,7 @@ func parseDirectiveDefinition(lexer: Lexer) throws -> DirectiveDefinition {
     do {
         try expectKeyword(lexer: lexer, value: "repeatable")
         try expectKeyword(lexer: lexer, value: "on")
+        try expectOptional(lexer: lexer, kind: .pipe)
         let locations = try parseDirectiveLocations(lexer: lexer)
         return DirectiveDefinition(
             loc: loc(lexer: lexer, startToken: start),
@@ -1214,6 +1217,7 @@ func parseDirectiveDefinition(lexer: Lexer) throws -> DirectiveDefinition {
         )
     } catch {
         try expectKeyword(lexer: lexer, value: "on")
+        try expectOptional(lexer: lexer, kind: .pipe)
         let locations = try parseDirectiveLocations(lexer: lexer)
         return DirectiveDefinition(
             loc: loc(lexer: lexer, startToken: start),

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -1190,7 +1190,7 @@ func parseInputObjectExtensionDefinition(lexer: Lexer) throws -> InputObjectExte
 
 /**
  * DirectiveDefinition :
- *   - directive @ Name ArgumentsDefinition? on DirectiveLocations
+ *   - directive @ Name ArgumentsDefinition? repeatable? on DirectiveLocations
  */
 func parseDirectiveDefinition(lexer: Lexer) throws -> DirectiveDefinition {
     let start = lexer.token
@@ -1199,15 +1199,30 @@ func parseDirectiveDefinition(lexer: Lexer) throws -> DirectiveDefinition {
     try expect(lexer: lexer, kind: .at)
     let name = try parseName(lexer: lexer)
     let args = try parseArgumentDefs(lexer: lexer)
-    try expectKeyword(lexer: lexer, value: "on")
-    let locations = try parseDirectiveLocations(lexer: lexer)
-    return DirectiveDefinition(
-        loc: loc(lexer: lexer, startToken: start),
-        description: description,
-        name: name,
-        arguments: args,
-        locations: locations
-    )
+
+    do {
+        try expectKeyword(lexer: lexer, value: "repeatable")
+        try expectKeyword(lexer: lexer, value: "on")
+        let locations = try parseDirectiveLocations(lexer: lexer)
+        return DirectiveDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            arguments: args,
+            locations: locations,
+            repeatable: true
+        )
+    } catch {
+        try expectKeyword(lexer: lexer, value: "on")
+        let locations = try parseDirectiveLocations(lexer: lexer)
+        return DirectiveDefinition(
+            loc: loc(lexer: lexer, startToken: start),
+            description: description,
+            name: name,
+            arguments: args,
+            locations: locations
+        )
+    }
 }
 
 /**

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -1343,6 +1343,20 @@ func expectKeyword(lexer: Lexer, value: String) throws -> Token {
 }
 
 /**
+* If the next token is a given keyword, return "true" after advancing the lexer.
+* Otherwise, do not change the parser state and return "false".
+*/
+@discardableResult
+func expectOptionalKeyword(lexer: Lexer, value: String) throws -> Bool {
+    let token = lexer.token
+    guard token.kind == .name && token.value == value else {
+        return false
+    }
+    try lexer.advance()
+    return true
+}
+
+/**
  * Helper func for creating an error when an unexpected lexed token
  * is encountered.
  */
@@ -1374,6 +1388,23 @@ func any<T>(
         nodes.append(try parse(lexer))
     }
 
+    return nodes
+}
+
+/**
+* Returns a list of parse nodes, determined by the parseFn.
+* It can be empty only if open token is missing otherwise it will always return non-empty list
+* that begins with a lex token of openKind and ends with a lex token of closeKind.
+* Advances the parser to the next lex token after the closing token.
+*/
+func optionalMany<T>(lexer: Lexer, openKind: Token.Kind, closeKind: Token.Kind, parse: (Lexer) throws -> T) throws -> [T] {
+    guard try expectOptional(lexer: lexer, kind: openKind) != nil else {
+        return []
+    }
+    var nodes: [T] = []
+    while try !skip(lexer: lexer, kind: closeKind) {
+        nodes.append(try parse(lexer))
+    }
     return nodes
 }
 

--- a/Tests/GraphQLTests/LanguageTests/ParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/ParserTests.swift
@@ -121,7 +121,9 @@ class ParserTests: XCTestCase {
             ))
         }
 
-        XCTAssertThrowsError(try parse(source: "type WithImplementsWithTrailingAmp implements AInterface & {}")) { error in
+        XCTAssertThrowsError(
+            try parse(source: "type WithImplementsWithTrailingAmp implements AInterface & {}")
+        ) { error in
             guard let error = error as? GraphQLError else {
                 return XCTFail()
             }

--- a/Tests/GraphQLTests/LanguageTests/ParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/ParserTests.swift
@@ -110,6 +110,26 @@ class ParserTests: XCTestCase {
                 "Syntax Error GraphQL (1:9) Expected Name, found }"
             ))
         }
+
+        XCTAssertThrowsError(try parse(source: "type WithImplementsButNoTypes implements {}")) { error in
+            guard let error = error as? GraphQLError else {
+                return XCTFail()
+            }
+
+            XCTAssert(error.message.contains(
+                "Syntax Error GraphQL (1:42) Expected Name, found {"
+            ))
+        }
+
+        XCTAssertThrowsError(try parse(source: "type WithImplementsWithTrailingAmp implements AInterface & {}")) { error in
+            guard let error = error as? GraphQLError else {
+                return XCTFail()
+            }
+
+            XCTAssert(error.message.contains(
+                "Syntax Error GraphQL (1:60) Expected Name, found {"
+            ))
+        }
     }
 
     func testVariableInlineValues() throws {

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -214,7 +214,7 @@ class SchemaParserTests: XCTestCase {
     }
 
     func testSimpleTypeInheritingMultipleInterfaces() throws {
-        let source = "type Hello implements Wo, rld { }"
+        let source = "type Hello implements Wo & rld { }"
 
         let expected = Document(
             definitions: [

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -844,6 +844,250 @@ class SchemaParserTests: XCTestCase {
         XCTAssert(result == expected)
     }
 
+    func testUndefinedType() throws {
+        let source = #"type UndefinedType"#
+
+        let expected = Document(
+            definitions: [
+                ObjectTypeDefinition(name: nameNode("UndefinedType"))
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testUndefinedInterfaceType() throws {
+        let source = #"interface UndefinedInterface"#
+
+        let expected = Document(
+            definitions: [
+                InterfaceTypeDefinition(
+                    name: nameNode("UndefinedInterface"),
+                    fields: [])
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testInterfaceExtensionType() throws {
+        let source = #"extend interface Bar @onInterface"#
+
+        let expected = Document(
+            definitions: [
+                InterfaceExtensionDefinition(
+                    definition: InterfaceTypeDefinition(
+                        name: nameNode("Bar"),
+                        directives: [
+                            Directive(name: nameNode("onInterface"))
+                        ],
+                        fields: []))
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testUnionPipe() throws {
+        let source = #"union AnnotatedUnionTwo @onUnion = | A | B"#
+
+        let expected = Document(
+            definitions: [
+                UnionTypeDefinition(
+                    name: nameNode("AnnotatedUnionTwo"),
+                    directives: [
+                        Directive(name: nameNode("onUnion"))
+                    ],
+                    types: [
+                        NamedType(name: nameNode("A")),
+                        NamedType(name: nameNode("B")),
+                    ])
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testExtendScalar() throws {
+        let source = #"extend scalar CustomScalar @onScalar"#
+
+        let expected = Document(
+            definitions: [
+                ScalarExtensionDefinition(
+                    definition: ScalarTypeDefinition(
+                        name: nameNode("CustomScalar"),
+                        directives: [
+                            Directive(name: nameNode("onScalar"))
+                        ]
+                    )
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testUndefinedUnion() throws {
+        let source = #"union UndefinedUnion"#
+
+        let expected = Document(
+            definitions: [
+                UnionTypeDefinition(
+                    name: nameNode("UndefinedUnion"),
+                    types: []
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testExtendUnion() throws {
+        let source = #"extend union Feed = Photo | Video"#
+
+        let expected = Document(
+            definitions: [
+                UnionExtensionDefinition(
+                    definition: UnionTypeDefinition(
+                        name: nameNode("Feed"),
+                        types: [
+                            namedTypeNode("Photo"),
+                            namedTypeNode("Video"),
+                        ]
+                    )
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testUndefinedEnum() throws {
+        let source = #"enum UndefinedEnum"#
+
+        let expected = Document(
+            definitions: [
+                EnumTypeDefinition(
+                    name: nameNode("UndefinedEnum"),
+                    values: []
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testEnumExtension() throws {
+        let source = #"extend enum Site @onEnum"#
+
+        let expected = Document(
+            definitions: [
+                EnumExtensionDefinition(
+                    definition: EnumTypeDefinition(
+                        name: nameNode("Site"),
+                        directives: [
+                            Directive(name: nameNode("onEnum"))
+                        ],
+                        values: []
+                    )
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testUndefinedInput() throws {
+        let source = #"input UndefinedInput"#
+
+        let expected = Document(
+            definitions: [
+                InputObjectTypeDefinition(
+                    name: nameNode("UndefinedInput"),
+                    fields: []
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testInputExtension() throws {
+        let source = #"extend input InputType"#
+
+        let expected = Document(
+            definitions: [
+                InputObjectExtensionDefinition(
+                    definition: InputObjectTypeDefinition(
+                        name: nameNode("InputType"),
+                        fields: []
+                    )
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testDirectivePipe() throws {
+        let source = """
+        directive @include2 on
+            | FIELD
+            | FRAGMENT_SPREAD
+            | INLINE_FRAGMENT
+        """
+
+        let expected = Document(
+            definitions: [
+                DirectiveDefinition(
+                    name: nameNode("include2"),
+                    locations: [
+                        nameNode("FIELD"),
+                        nameNode("FRAGMENT_SPREAD"),
+                        nameNode("INLINE_FRAGMENT")
+                    ])
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
+    func testDirectiveRepeatable() throws {
+        let source = """
+        directive @myRepeatableDir repeatable on
+          | OBJECT
+          | INTERFACE
+        """
+
+        let expected = Document(
+            definitions: [
+                DirectiveDefinition(
+                    name: nameNode("myRepeatableDir"),
+                    locations: [
+                        nameNode("OBJECT"),
+                        nameNode("INTERFACE"),
+                    ],
+                    repeatable: true
+                )
+            ]
+        )
+
+        let result = try parse(source: source)
+        XCTAssert(result == expected)
+    }
+
     func testKitchenSink() throws {
         guard
             let url = Bundle.module.url(

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -849,7 +849,7 @@ class SchemaParserTests: XCTestCase {
 
         let expected = Document(
             definitions: [
-                ObjectTypeDefinition(name: nameNode("UndefinedType"))
+                ObjectTypeDefinition(name: nameNode("UndefinedType")),
             ]
         )
 
@@ -864,7 +864,8 @@ class SchemaParserTests: XCTestCase {
             definitions: [
                 InterfaceTypeDefinition(
                     name: nameNode("UndefinedInterface"),
-                    fields: [])
+                    fields: []
+                ),
             ]
         )
 
@@ -881,9 +882,11 @@ class SchemaParserTests: XCTestCase {
                     definition: InterfaceTypeDefinition(
                         name: nameNode("Bar"),
                         directives: [
-                            Directive(name: nameNode("onInterface"))
+                            Directive(name: nameNode("onInterface")),
                         ],
-                        fields: []))
+                        fields: []
+                    )
+                ),
             ]
         )
 
@@ -899,12 +902,13 @@ class SchemaParserTests: XCTestCase {
                 UnionTypeDefinition(
                     name: nameNode("AnnotatedUnionTwo"),
                     directives: [
-                        Directive(name: nameNode("onUnion"))
+                        Directive(name: nameNode("onUnion")),
                     ],
                     types: [
                         NamedType(name: nameNode("A")),
                         NamedType(name: nameNode("B")),
-                    ])
+                    ]
+                ),
             ]
         )
 
@@ -921,10 +925,10 @@ class SchemaParserTests: XCTestCase {
                     definition: ScalarTypeDefinition(
                         name: nameNode("CustomScalar"),
                         directives: [
-                            Directive(name: nameNode("onScalar"))
+                            Directive(name: nameNode("onScalar")),
                         ]
                     )
-                )
+                ),
             ]
         )
 
@@ -940,7 +944,7 @@ class SchemaParserTests: XCTestCase {
                 UnionTypeDefinition(
                     name: nameNode("UndefinedUnion"),
                     types: []
-                )
+                ),
             ]
         )
 
@@ -961,7 +965,7 @@ class SchemaParserTests: XCTestCase {
                             namedTypeNode("Video"),
                         ]
                     )
-                )
+                ),
             ]
         )
 
@@ -977,7 +981,7 @@ class SchemaParserTests: XCTestCase {
                 EnumTypeDefinition(
                     name: nameNode("UndefinedEnum"),
                     values: []
-                )
+                ),
             ]
         )
 
@@ -994,11 +998,11 @@ class SchemaParserTests: XCTestCase {
                     definition: EnumTypeDefinition(
                         name: nameNode("Site"),
                         directives: [
-                            Directive(name: nameNode("onEnum"))
+                            Directive(name: nameNode("onEnum")),
                         ],
                         values: []
                     )
-                )
+                ),
             ]
         )
 
@@ -1014,7 +1018,7 @@ class SchemaParserTests: XCTestCase {
                 InputObjectTypeDefinition(
                     name: nameNode("UndefinedInput"),
                     fields: []
-                )
+                ),
             ]
         )
 
@@ -1032,7 +1036,7 @@ class SchemaParserTests: XCTestCase {
                         name: nameNode("InputType"),
                         fields: []
                     )
-                )
+                ),
             ]
         )
 
@@ -1055,8 +1059,9 @@ class SchemaParserTests: XCTestCase {
                     locations: [
                         nameNode("FIELD"),
                         nameNode("FRAGMENT_SPREAD"),
-                        nameNode("INLINE_FRAGMENT")
-                    ])
+                        nameNode("INLINE_FRAGMENT"),
+                    ]
+                ),
             ]
         )
 
@@ -1080,7 +1085,7 @@ class SchemaParserTests: XCTestCase {
                         nameNode("INTERFACE"),
                     ],
                     repeatable: true
-                )
+                ),
             ]
         )
 

--- a/Tests/GraphQLTests/LanguageTests/schema-kitchen-sink.graphql
+++ b/Tests/GraphQLTests/LanguageTests/schema-kitchen-sink.graphql
@@ -10,18 +10,41 @@ schema {
   mutation: MutationType
 }
 
-type Foo implements Bar {
+"""
+This is a description
+of the `Foo` type.
+"""
+type Foo implements Bar & Baz & Two {
+  "Description of the `one` field."
   one: Type
-  two(argument: InputType!): Type
+  """
+  This is a description of the `two` field.
+  """
+  two(
+    """
+    This is a description of the `argument` argument.
+    """
+    argument: InputType!
+  ): Type
+  """This is a description of the `three` field."""
   three(argument: InputType, other: String): Int
   four(argument: String = "string"): String
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
+  seven(argument: Int = null): Type
 }
 
 type AnnotatedObject @onObject(arg: "value") {
-  annotatedField(arg: Type = "default" @onArg): Type @onField
+  annotatedField(arg: Type = "default" @onArgumentDefinition): Type @onField
 }
+
+type UndefinedType
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+
+extend type Foo @onType
 
 interface Bar {
   one: Type
@@ -29,20 +52,55 @@ interface Bar {
 }
 
 interface AnnotatedInterface @onInterface {
-  annotatedField(arg: Type @onArg): Type @onField
+  annotatedField(arg: Type @onArgumentDefinition): Type @onField
 }
 
-union Feed = Story | Article | Advert
+interface UndefinedInterface
+
+extend interface Bar implements Two {
+  two(argument: InputType!): Type
+}
+
+extend interface Bar @onInterface
+
+interface Baz implements Bar & Two {
+  one: Type
+  two(argument: InputType!): Type
+  four(argument: String = "string"): String
+}
+
+union Feed =
+  | Story
+  | Article
+  | Advert
 
 union AnnotatedUnion @onUnion = A | B
+
+union AnnotatedUnionTwo @onUnion = | A | B
+
+union UndefinedUnion
+
+extend union Feed = Photo | Video
+
+extend union Feed @onUnion
 
 scalar CustomScalar
 
 scalar AnnotatedScalar @onScalar
 
+extend scalar CustomScalar @onScalar
+
 enum Site {
+  """
+  This is a description of the `DESKTOP` value
+  """
   DESKTOP
+
+  """This is a description of the `MOBILE` value"""
   MOBILE
+
+  "This is a description of the `WEB` value"
+  WEB
 }
 
 enum AnnotatedEnum @onEnum {
@@ -50,26 +108,55 @@ enum AnnotatedEnum @onEnum {
   OTHER_VALUE
 }
 
+enum UndefinedEnum
+
+extend enum Site {
+  VR
+}
+
+extend enum Site @onEnum
+
 input InputType {
   key: String!
   answer: Int = 42
 }
 
-input AnnotatedInput @onInputObjectType {
-  annotatedField: Type @onField
+input AnnotatedInput @onInputObject {
+  annotatedField: Type @onInputFieldDefinition
 }
 
-extend type Foo {
-  seven(argument: [String]): Type
+input UndefinedInput
+
+extend input InputType {
+  other: Float = 1.23e4 @onInputFieldDefinition
 }
 
-extend type Foo @onType {}
+extend input InputType @onInputObject
 
-type NoFields {}
-
-directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+"""
+This is a description of the `@skip` directive
+"""
+directive @skip(
+  """This is a description of the `if` argument"""
+  if: Boolean! @onArgumentDefinition
+) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 directive @include(if: Boolean!)
   on FIELD
    | FRAGMENT_SPREAD
    | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on
+  | FIELD
+  | FRAGMENT_SPREAD
+  | INLINE_FRAGMENT
+
+directive @myRepeatableDir(name: String!) repeatable on
+  | OBJECT
+  | INTERFACE
+
+extend schema @onSchema
+
+extend schema @onSchema {
+  subscription: SubscriptionType
+}


### PR DESCRIPTION
- Adds ampersand support from #73
- Adds support for `extend` for `interface`, `scalar`, `union`, `enum` and `input`
- Adds support for undefined types ie `extend enum Site`
- Adds support for `repeatable` on directives
- Adds support for leading pipe on enum/directives
- Updates kitchen sink schema to match https://github.com/graphql/graphql-js/blob/main/src/__testUtils__/kitchenSinkSDL.ts