### PR TITLE
fix: Serial Execution Strategy

### DIFF
--- a/Sources/GraphQL/Utilities/NIO+Extensions.swift
+++ b/Sources/GraphQL/Utilities/NIO+Extensions.swift
@@ -101,3 +101,31 @@ public protocol FutureType {
 extension Future: FutureType {
     public typealias Expectation = Value
 }
+
+// Copied from https://github.com/vapor/async-kit/blob/e2f741640364c1d271405da637029ea6a33f754e/Sources/AsyncKit/EventLoopFuture/Future%2BTry.swift
+// in order to avoid full package dependency.
+public extension EventLoopFuture {
+    func tryFlatMap<NewValue>(
+        file _: StaticString = #file, line _: UInt = #line,
+        _ callback: @escaping (Value) throws -> EventLoopFuture<NewValue>
+    ) -> EventLoopFuture<NewValue> {
+        /// When the current `EventLoopFuture<Value>` is fulfilled, run the provided callback,
+        /// which will provide a new `EventLoopFuture`.
+        ///
+        /// This allows you to dynamically dispatch new asynchronous tasks as phases in a
+        /// longer series of processing steps. Note that you can use the results of the
+        /// current `EventLoopFuture<Value>` when determining how to dispatch the next operation.
+        ///
+        /// The key difference between this method and the regular `flatMap` is  error handling.
+        ///
+        /// With `tryFlatMap`, the provided callback _may_ throw Errors, causing the returned `EventLoopFuture<Value>`
+        /// to report failure immediately after the completion of the original `EventLoopFuture`.
+        flatMap { [eventLoop] value in
+            do {
+                return try callback(value)
+            } catch {
+                return eventLoop.makeFailedFuture(error)
+            }
+        }
+    }
+}

--- a/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
+++ b/Tests/GraphQLTests/FieldExecutionStrategyTests/FieldExecutionStrategyTests.swift
@@ -15,15 +15,10 @@ class FieldExecutionStrategyTests: XCTestCase {
                 "sleep": GraphQLField(
                     type: GraphQLString,
                     resolve: { _, _, _, eventLoopGroup, _ in
-                        let group = DispatchGroup()
-                        group.enter()
-
-                        DispatchQueue.global().asyncAfter(wallDeadline: .now() + 0.1) {
-                            group.leave()
+                        eventLoopGroup.next().makeSucceededVoidFuture().map {
+                            Thread.sleep(forTimeInterval: 0.1)
+                            return "z"
                         }
-
-                        group.wait()
-                        return eventLoopGroup.next().makeSucceededFuture("z")
                     }
                 ),
                 "bang": GraphQLField(
@@ -251,7 +246,7 @@ class FieldExecutionStrategyTests: XCTestCase {
             eventLoopGroup: eventLoopGroup
         ).wait())
         XCTAssertEqual(result.value, multiExpected)
-        // XCTAssertEqualWithAccuracy(1.0, result.seconds, accuracy: 0.5)
+//        XCTAssertEqualWithAccuracy(1.0, result.seconds, accuracy: 0.5)
     }
 
     func testSerialFieldExecutionStrategyWithMultipleFieldErrors() throws {
@@ -300,7 +295,7 @@ class FieldExecutionStrategyTests: XCTestCase {
             eventLoopGroup: eventLoopGroup
         ).wait())
         XCTAssertEqual(result.value, multiExpected)
-        // XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
+//        XCTAssertEqualWithAccuracy(0.1, result.seconds, accuracy: 0.25)
     }
 
     func testConcurrentDispatchFieldExecutionStrategyWithMultipleFieldErrors() throws {


### PR DESCRIPTION
Exposed a bug in mocks for `FieldExecutionStrategyTests` affecting `testSerialFieldExecutionStrategyWithMultipleFieldErrors`.

Prior to the change, the test appeared to be serial because the mocking framework blocked execution *before* returning the future - as opposed to blocking execution on the EventLoop.

The `SerialFieldExecutionStrategy` execution resolution implementation used NIO's `.flatten` on an array of futures (which all executed concurrently). However, the creation of these futures was thread blocked specifically in the tests, leading to the appearance of serial execution.

These changes correct the catalyzing test mock as well as `SerialFieldExecutionStrategy` such that it resolves fields in a truly serial fashion.