### PR TITLE
Port Printer from graphql-js

### DIFF
--- a/Sources/GraphQL/Language/Printer.swift
+++ b/Sources/GraphQL/Language/Printer.swift
@@ -6,11 +6,11 @@ func print(ast: Node) -> String {
     ast.printed
 }
 
-fileprivate protocol Printable {
+private protocol Printable {
     var printed: String { get }
 }
 
-fileprivate let MAX_LINE_LENGTH = 80
+private let MAX_LINE_LENGTH = 80
 
 extension Name: Printable {
     var printed: String { value }
@@ -36,7 +36,7 @@ extension OperationDefinition: Printable {
         let prefix = join([
             operation.rawValue,
             join([name, varDefs]),
-            join(directives, " ")
+            join(directives, " "),
         ], " ")
 
         // Anonymous queries with no directives or variable definitions can use
@@ -73,7 +73,7 @@ extension Field: Printable {
             argsLine,
             wrap(" ", join(directives, " ")),
             wrap(" ", selectionSet),
-        ]);
+        ])
     }
 }
 
@@ -84,6 +84,7 @@ extension Argument: Printable {
 }
 
 // TODO: Add Nullability Modifiers
+
 // MARK: - Nullability Modifiers
 
 //
@@ -117,14 +118,15 @@ extension InlineFragment: Printable {
             "...",
             wrap("on ", typeCondition),
             join(directives, " "),
-            selectionSet
+            selectionSet,
         ], " ")
     }
 }
 
 extension FragmentDefinition: Printable {
     var printed: String {
-        "fragment " + name + " on " + typeCondition + " " + wrap("", join(directives, " "), " ") + selectionSet
+        "fragment " + name + " on " + typeCondition + " " + wrap("", join(directives, " "), " ") +
+            selectionSet
     }
 }
 
@@ -210,8 +212,8 @@ extension NonNullType: Printable {
 
 extension SchemaDefinition: Printable {
     var printed: String {
-        wrap("", description, "\n") + 
-        join(["schema", join(directives, " "), block(operationTypes)], " ")
+        wrap("", description, "\n") +
+            join(["schema", join(directives, " "), block(operationTypes)], " ")
     }
 }
 
@@ -221,15 +223,24 @@ extension OperationTypeDefinition: Printable {
 
 extension ScalarTypeDefinition: Printable {
     var printed: String {
-        wrap("", description, "\n") + 
-        join(["scalar", name.printed, join(directives, " ")], " ")
+        wrap("", description, "\n") +
+            join(["scalar", name.printed, join(directives, " ")], " ")
     }
 }
 
 extension ObjectTypeDefinition: Printable {
     var printed: String {
         wrap("", description, "\n") +
-        join(["type", name, wrap("implements ", join(interfaces, " & ")), join(directives, " "), block(fields)], " ")
+            join(
+                [
+                    "type",
+                    name,
+                    wrap("implements ", join(interfaces, " & ")),
+                    join(directives, " "),
+                    block(fields),
+                ],
+                " "
+            )
     }
 }
 
@@ -248,42 +259,58 @@ extension FieldDefinition: Printable {
 extension InputValueDefinition: Printable {
     var printed: String {
         wrap("", description, "\n") +
-        join([name + ": " + type.printed, wrap("= ", defaultValue?.printed), join(directives, " ")], " ")
+            join(
+                [
+                    name + ": " + type.printed,
+                    wrap("= ", defaultValue?.printed),
+                    join(directives, " "),
+                ],
+                " "
+            )
     }
 }
 
 extension InterfaceTypeDefinition: Printable {
     var printed: String {
         wrap("", description, "\n") +
-        join(["interface", name, wrap("implements ", join(interfaces, " & ")), join(directives, " "), block(fields)], " ")
+            join(
+                [
+                    "interface",
+                    name,
+                    wrap("implements ", join(interfaces, " & ")),
+                    join(directives, " "),
+                    block(fields),
+                ],
+                " "
+            )
     }
 }
 
 extension UnionTypeDefinition: Printable {
     var printed: String {
         wrap("", description, "\n") +
-        join(["union", name, join(directives, " "), wrap("= ", join(types, " | "))], " ")
+            join(["union", name, join(directives, " "), wrap("= ", join(types, " | "))], " ")
     }
 }
 
 extension EnumTypeDefinition: Printable {
     var printed: String {
         wrap("", description, "\n") +
-        join(["enum", name, join(directives, " "), block(values)], " ")
+            join(["enum", name, join(directives, " "), block(values)], " ")
     }
 }
 
 extension EnumValueDefinition: Printable {
     var printed: String {
-        wrap("", description, "\n") + 
-        join([name, join(directives, " ")], " ")
+        wrap("", description, "\n") +
+            join([name, join(directives, " ")], " ")
     }
 }
 
 extension InputObjectTypeDefinition: Printable {
     var printed: String {
         wrap("", description, "\n") +
-        join(["input", name, join(directives, " "), block(fields)], " ")
+            join(["input", name, join(directives, " "), block(fields)], " ")
     }
 }
 
@@ -292,8 +319,8 @@ extension DirectiveDefinition: Printable {
         let prefix = wrap("", description, "\n") + "directive @" + name
 
         let args = hasMultilineItems(arguments) ?
-        wrap("(\n", indent(join(arguments, "\n")), "\n)") :
-        wrap("(", join(arguments, ", "), ")")
+            wrap("(\n", indent(join(arguments, "\n")), "\n)") :
+            wrap("(", join(arguments, ", "), ")")
 
         return prefix + args + (repeatable ? " repeatable" : "") + " on " + join(locations, " | ")
     }
@@ -342,58 +369,58 @@ extension InputObjectExtensionDefinition: Printable {
 }
 
 /// If content is not null or empty, then wrap with start and end, otherwise print an empty string.
-fileprivate func wrap(_ start: String, _ content: String?, _ end: String = "") -> String {
+private func wrap(_ start: String, _ content: String?, _ end: String = "") -> String {
     guard let content = content, !content.isEmpty else {
         return ""
     }
     return start + content + end
 }
 
-fileprivate func wrap(_ start: String, _ content: Printable?, _ end: String = "") -> String {
+private func wrap(_ start: String, _ content: Printable?, _ end: String = "") -> String {
     wrap(start, content?.printed, end)
 }
 
-fileprivate func indent(_ string: String) -> String {
+private func indent(_ string: String) -> String {
     wrap("  ", string.replacingOccurrences(of: "\n", with: "\n  "))
 }
 
-fileprivate func indent(_ string: Printable) -> String {
+private func indent(_ string: Printable) -> String {
     indent(string.printed)
 }
 
 /// Given array, print an empty string if it is null or empty, otherwise
 /// print all items together separated by separator if provided
-fileprivate func join(_ array: [String?]?, _ seperator: String = "") -> String {
+private func join(_ array: [String?]?, _ seperator: String = "") -> String {
     array?.compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: seperator) ?? ""
 }
 
-fileprivate func join(_ array: [Printable?]?, _ seperator: String = "") -> String {
+private func join(_ array: [Printable?]?, _ seperator: String = "") -> String {
     join(array?.map { $0?.printed }, seperator)
 }
 
 /// Given array, print each item on its own line, wrapped in an indented `{ }` block.
-fileprivate func block(_ array: [String?]?) -> String {
+private func block(_ array: [String?]?) -> String {
     wrap("{\n", indent(join(array, "\n")), "\n}")
 }
 
-fileprivate func block(_ array: [Printable?]?) -> String {
+private func block(_ array: [Printable?]?) -> String {
     block(array?.map { $0?.printed })
 }
 
-fileprivate func hasMultilineItems(_ array: [String]?) -> Bool {
+private func hasMultilineItems(_ array: [String]?) -> Bool {
     // FIXME: https://github.com/graphql/graphql-js/issues/2203
     array?.contains { x in x.contains { $0.isNewline } } ?? false
 }
 
-fileprivate func hasMultilineItems(_ array: [Printable]?) -> Bool {
+private func hasMultilineItems(_ array: [Printable]?) -> Bool {
     hasMultilineItems(array?.map { $0.printed })
 }
 
-fileprivate func +(lhs: String, rhs: Printable) -> String {
+private func + (lhs: String, rhs: Printable) -> String {
     lhs + rhs.printed
 }
 
-fileprivate func +(lhs: Printable, rhs: String) -> String {
+private func + (lhs: Printable, rhs: String) -> String {
     lhs.printed + rhs
 }
 
@@ -401,26 +428,26 @@ extension String: Printable {
     fileprivate var printed: String { self }
 }
 
-extension Node {
-    fileprivate var printed: String {
+private extension Node {
+    var printed: String {
         (self as? Printable)?.printed ?? "UnknownNode"
     }
 }
 
-extension Value {
-    fileprivate var printed: String {
+private extension Value {
+    var printed: String {
         (self as? Printable)?.printed ?? "UnknownValue"
     }
 }
 
-extension Selection {
-    fileprivate var printed: String {
+private extension Selection {
+    var printed: String {
         (self as? Printable)?.printed ?? "UnknownSelection"
     }
 }
 
-extension `Type` {
-    fileprivate var printed: String {
+private extension Type {
+    var printed: String {
         (self as? Printable)?.printed ?? "UnknownType"
     }
 }

--- a/Sources/GraphQL/Language/Printer.swift
+++ b/Sources/GraphQL/Language/Printer.swift
@@ -1,0 +1,426 @@
+import Foundation
+
+/// Converts an AST into a string, using one set of reasonable
+/// formatting rules.
+func print(ast: Node) -> String {
+    ast.printed
+}
+
+fileprivate protocol Printable {
+    var printed: String { get }
+}
+
+fileprivate let MAX_LINE_LENGTH = 80
+
+extension Name: Printable {
+    var printed: String { value }
+}
+
+extension Variable: Printable {
+    var printed: String { "$" + name }
+}
+
+// MARK: - Document
+
+extension Document: Printable {
+    var printed: String {
+        // Since Definition is a protocol
+        let definitions = definitions.map { $0 as? Printable }
+        return join(definitions, "\n\n")
+    }
+}
+
+extension OperationDefinition: Printable {
+    var printed: String {
+        let varDefs = wrap("(", join(variableDefinitions, ", "), ")")
+        let prefix = join([
+            operation.rawValue,
+            join([name, varDefs]),
+            join(directives, " ")
+        ], " ")
+
+        // Anonymous queries with no directives or variable definitions can use
+        // the query short form.
+        return (prefix == "query" ? "" : prefix + " ") + selectionSet
+    }
+}
+
+extension VariableDefinition: Printable {
+    var printed: String {
+        variable + ": " + type.printed + wrap(" = ", defaultValue?.printed)
+//        + wrap(" ", join(directives, " "))
+        // TODO: variable directives are currently not supported
+    }
+}
+
+extension SelectionSet: Printable {
+    var printed: String {
+        let selections = selections.map { $0 as? Printable }
+        return block(selections)
+    }
+}
+
+extension Field: Printable {
+    var printed: String {
+        let prefix = join([wrap("", alias, ": "), name], "")
+        var argsLine = prefix + wrap("(", join(arguments, ", "), ")")
+
+        if argsLine.count > MAX_LINE_LENGTH {
+            argsLine = prefix + wrap("(\n", indent(join(arguments, "\n")), "\n)")
+        }
+
+        return join([
+            argsLine,
+            wrap(" ", join(directives, " ")),
+            wrap(" ", selectionSet),
+        ]);
+    }
+}
+
+extension Argument: Printable {
+    var printed: String {
+        return name + ": " + value.printed
+    }
+}
+
+// TODO: Add Nullability Modifiers
+// MARK: - Nullability Modifiers
+
+//
+//  ListNullabilityOperator: {
+//    leave({ nullabilityAssertion }) {
+//      return join(['[', nullabilityAssertion, ']']);
+//    },
+//  },
+//
+//  NonNullAssertion: {
+//    leave({ nullabilityAssertion }) {
+//      return join([nullabilityAssertion, '!']);
+//    },
+//  },
+//
+//  ErrorBoundary: {
+//    leave({ nullabilityAssertion }) {
+//      return join([nullabilityAssertion, '?']);
+//    },
+//  },
+
+// MARK: - Fragments
+
+extension FragmentSpread: Printable {
+    var printed: String { "..." + name + wrap(" ", join(directives, " ")) }
+}
+
+extension InlineFragment: Printable {
+    var printed: String {
+        join([
+            "...",
+            wrap("on ", typeCondition),
+            join(directives, " "),
+            selectionSet
+        ], " ")
+    }
+}
+
+extension FragmentDefinition: Printable {
+    var printed: String {
+        "fragment " + name + " on " + typeCondition + " " + wrap("", join(directives, " "), " ") + selectionSet
+    }
+}
+
+// MARK: - Value
+
+extension IntValue: Printable {
+    var printed: String { value }
+}
+
+extension FloatValue: Printable {
+    var printed: String { value }
+}
+
+extension StringValue: Printable {
+    var printed: String {
+        block == true ? value : "\"\(value)\""
+        // TODO: isBlockString === true ? printBlockString(value) : printString(value),
+    }
+}
+
+extension BooleanValue: Printable {
+    var printed: String { value ? "true" : "false" }
+}
+
+extension NullValue: Printable {
+    var printed: String { "null" }
+}
+
+extension EnumValue: Printable {
+    var printed: String { value }
+}
+
+extension ListValue: Printable {
+    var printed: String {
+        let values = values.map { $0 as? Printable }
+        let valuesLine = "[" + join(values, ", ") + "]"
+
+        if valuesLine.count > MAX_LINE_LENGTH {
+            return "[\n" + indent(join(values, "\n")) + "\n]"
+        }
+
+        return valuesLine
+    }
+}
+
+extension ObjectValue: Printable {
+    var printed: String {
+        let fieldsLine = "{ " + join(fields, ", ") + " }"
+
+        if fieldsLine.count > MAX_LINE_LENGTH {
+            return block(fields)
+        }
+
+        return fieldsLine
+    }
+}
+
+extension ObjectField: Printable {
+    var printed: String { name + ": " + value.printed }
+}
+
+// MARK: - Directive
+
+extension Directive: Printable {
+    var printed: String { "@" + name + wrap("(", join(arguments, ", "), ")") }
+}
+
+// MARK: - Type
+
+extension NamedType: Printable {
+    var printed: String { name.printed }
+}
+
+extension ListType: Printable {
+    var printed: String { "[" + type.printed + "]" }
+}
+
+extension NonNullType: Printable {
+    var printed: String { type.printed + "!" }
+}
+
+// MARK: - Type System Definitions
+
+extension SchemaDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") + 
+        join(["schema", join(directives, " "), block(operationTypes)], " ")
+    }
+}
+
+extension OperationTypeDefinition: Printable {
+    var printed: String { operation.rawValue + ": " + type }
+}
+
+extension ScalarTypeDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") + 
+        join(["scalar", name.printed, join(directives, " ")], " ")
+    }
+}
+
+extension ObjectTypeDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") +
+        join(["type", name, wrap("implements ", join(interfaces, " & ")), join(directives, " "), block(fields)], " ")
+    }
+}
+
+extension FieldDefinition: Printable {
+    var printed: String {
+        let prefix = wrap("", description, "\n") + name
+
+        let args = hasMultilineItems(arguments) ?
+            wrap("(\n", indent(join(arguments, "\n")), "\n)") :
+            wrap("(", join(arguments, ", "), ")")
+
+        return prefix + args + ": " + type.printed + wrap(" ", join(directives, " "))
+    }
+}
+
+extension InputValueDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") +
+        join([name + ": " + type.printed, wrap("= ", defaultValue?.printed), join(directives, " ")], " ")
+    }
+}
+
+extension InterfaceTypeDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") +
+        join(["interface", name, wrap("implements ", join(interfaces, " & ")), join(directives, " "), block(fields)], " ")
+    }
+}
+
+extension UnionTypeDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") +
+        join(["union", name, join(directives, " "), wrap("= ", join(types, " | "))], " ")
+    }
+}
+
+extension EnumTypeDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") +
+        join(["enum", name, join(directives, " "), block(values)], " ")
+    }
+}
+
+extension EnumValueDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") + 
+        join([name, join(directives, " ")], " ")
+    }
+}
+
+extension InputObjectTypeDefinition: Printable {
+    var printed: String {
+        wrap("", description, "\n") +
+        join(["input", name, join(directives, " "), block(fields)], " ")
+    }
+}
+
+extension DirectiveDefinition: Printable {
+    var printed: String {
+        let prefix = wrap("", description, "\n") + "directive @" + name
+
+        let args = hasMultilineItems(arguments) ?
+        wrap("(\n", indent(join(arguments, "\n")), "\n)") :
+        wrap("(", join(arguments, ", "), ")")
+
+        return prefix + args + (repeatable ? " repeatable" : "") + " on " + join(locations, " | ")
+    }
+}
+
+extension SchemaExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+extension ScalarExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+extension TypeExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+extension InterfaceExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+extension UnionExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+extension EnumExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+extension InputObjectExtensionDefinition: Printable {
+    var printed: String {
+        join(["extend", definition], " ")
+    }
+}
+
+/// If content is not null or empty, then wrap with start and end, otherwise print an empty string.
+fileprivate func wrap(_ start: String, _ content: String?, _ end: String = "") -> String {
+    guard let content = content, !content.isEmpty else {
+        return ""
+    }
+    return start + content + end
+}
+
+fileprivate func wrap(_ start: String, _ content: Printable?, _ end: String = "") -> String {
+    wrap(start, content?.printed, end)
+}
+
+fileprivate func indent(_ string: String) -> String {
+    wrap("  ", string.replacingOccurrences(of: "\n", with: "\n  "))
+}
+
+fileprivate func indent(_ string: Printable) -> String {
+    indent(string.printed)
+}
+
+/// Given array, print an empty string if it is null or empty, otherwise
+/// print all items together separated by separator if provided
+fileprivate func join(_ array: [String?]?, _ seperator: String = "") -> String {
+    array?.compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: seperator) ?? ""
+}
+
+fileprivate func join(_ array: [Printable?]?, _ seperator: String = "") -> String {
+    join(array?.map { $0?.printed }, seperator)
+}
+
+/// Given array, print each item on its own line, wrapped in an indented `{ }` block.
+fileprivate func block(_ array: [String?]?) -> String {
+    wrap("{\n", indent(join(array, "\n")), "\n}")
+}
+
+fileprivate func block(_ array: [Printable?]?) -> String {
+    block(array?.map { $0?.printed })
+}
+
+fileprivate func hasMultilineItems(_ array: [String]?) -> Bool {
+    // FIXME: https://github.com/graphql/graphql-js/issues/2203
+    array?.contains { x in x.contains { $0.isNewline } } ?? false
+}
+
+fileprivate func hasMultilineItems(_ array: [Printable]?) -> Bool {
+    hasMultilineItems(array?.map { $0.printed })
+}
+
+fileprivate func +(lhs: String, rhs: Printable) -> String {
+    lhs + rhs.printed
+}
+
+fileprivate func +(lhs: Printable, rhs: String) -> String {
+    lhs.printed + rhs
+}
+
+extension String: Printable {
+    fileprivate var printed: String { self }
+}
+
+extension Node {
+    fileprivate var printed: String {
+        (self as? Printable)?.printed ?? "UnknownNode"
+    }
+}
+
+extension Value {
+    fileprivate var printed: String {
+        (self as? Printable)?.printed ?? "UnknownValue"
+    }
+}
+
+extension Selection {
+    fileprivate var printed: String {
+        (self as? Printable)?.printed ?? "UnknownSelection"
+    }
+}
+
+extension `Type` {
+    fileprivate var printed: String {
+        (self as? Printable)?.printed ?? "UnknownType"
+    }
+}

--- a/Tests/GraphQLTests/FederationTests/FederationTests.swift
+++ b/Tests/GraphQLTests/FederationTests/FederationTests.swift
@@ -6,34 +6,27 @@ final class FederationTests: XCTestCase {
         // Confirm that the Apollo test schema can be parsed as expected https://github.com/apollographql/apollo-federation-subgraph-compatibility/blob/main/COMPATIBILITY.md
         let source =
             """
-            extend schema
-              @link(
-                url: "https://specs.apollo.dev/federation/v2.0",
-                import: [
-                  "@extends",
-                  "@external",
-                  "@key",
-                  "@inaccessible",
-                  "@override",
-                  "@provides",
-                  "@requires",
-                  "@shareable",
-                  "@tag"
-                ]
-              )
+            extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: [
+              "@extends"
+              "@external"
+              "@key"
+              "@inaccessible"
+              "@override"
+              "@provides"
+              "@requires"
+              "@shareable"
+              "@tag"
+            ])
 
-            type Product
-              @key(fields: "id")
-              @key(fields: "sku package")
-              @key(fields: "sku variation { id }") {
-                id: ID!
-                sku: String
-                package: String
-                variation: ProductVariation
-                dimensions: ProductDimension
-                createdBy: User @provides(fields: "totalProductsCreated")
-                notes: String @tag(name: "internal")
-                research: [ProductResearch!]!
+            type Product @key(fields: "id") @key(fields: "sku package") @key(fields: "sku variation { id }") {
+              id: ID!
+              sku: String
+              package: String
+              variation: ProductVariation
+              dimensions: ProductDimension
+              createdBy: User @provides(fields: "totalProductsCreated")
+              notes: String @tag(name: "internal")
+              research: [ProductResearch!]!
             }
 
             type DeprecatedProduct @key(fields: "sku package") {
@@ -332,7 +325,10 @@ final class FederationTests: XCTestCase {
             userExtensionObjectTypeDefinition,
         ])
 
-        let result = try parse(source: source)
-        XCTAssert(result == expected)
+        let document = try parse(source: source)
+        let printed = print(ast: document)
+
+        XCTAssertEqual(document, expected)
+        XCTAssertEqual(source, printed)
     }
 }

--- a/Tests/GraphQLTests/LanguageTests/PrinterTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/PrinterTests.swift
@@ -10,55 +10,56 @@ class PrinterTests: XCTestCase {
     func testCorrectlyPrintNonQueryOperationsWithoutNameForQuery() throws {
         let document = try parse(source: "query { id, name }")
         let expected =
-        """
-        {
-          id
-          name
-        }
-        """
+            """
+            {
+              id
+              name
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
 
     func testCorrectlyPrintNonQueryOperationsWithoutNameForMutation() throws {
         let document = try parse(source: "mutation { id, name }")
         let expected =
-        """
-        mutation {
-          id
-          name
-        }
-        """
+            """
+            mutation {
+              id
+              name
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
-    
+
     func testCorrectlyPrintNonQueryOperationsWithoutNameForQueryWithArtifacts() throws {
         let document = try parse(source: "query ($foo: TestType) @testDirective { id, name }")
         let expected =
-        """
-        query ($foo: TestType) @testDirective {
-          id
-          name
-        }
-        """
+            """
+            query ($foo: TestType) @testDirective {
+              id
+              name
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
 
     func testCorrectlyPrintNonQueryOperationsWithoutNameForMutationWithArtifacts() throws {
         let document = try parse(source: "mutation ($foo: TestType) @testDirective { id, name }")
         let expected =
-        """
-        mutation ($foo: TestType) @testDirective {
-          id
-          name
-        }
-        """
+            """
+            mutation ($foo: TestType) @testDirective {
+              id
+              name
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
 
     // Variable Directives are currently not support by this library
     // TODO: Add support for variable directives
 //    func testPrintsQueryWithVariableDirectives() throws {
-//        let document = try parse(source: "query ($foo: TestType = { a: 123 } @testDirective(if: true) @test) { id }")
+//        let document = try parse(source: "query ($foo: TestType = { a: 123 } @testDirective(if:
+//        true) @test) { id }")
 //        let expected =
 //        """
 //        query ($foo: TestType = { a: 123 } @testDirective(if: true) @test) {
@@ -71,86 +72,95 @@ class PrinterTests: XCTestCase {
     func testKeepsArgumentsOnOneLineIfLineIsShort() throws {
         let document = try parse(source: "{trip(wheelchair:false arriveBy:false){dateTime}}")
         let expected =
-        """
-        {
-          trip(wheelchair: false, arriveBy: false) {
-            dateTime
-          }
-        }
-        """
+            """
+            {
+              trip(wheelchair: false, arriveBy: false) {
+                dateTime
+              }
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
-    
+
     func testPutsArgumentsOnMultipleLinesIfLineIsLong() throws {
-        let document = try parse(source: "{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}")
+        let document =
+            try parse(
+                source: "{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}"
+            )
         let expected =
-        """
-        {
-          trip(
-            wheelchair: false
-            arriveBy: false
-            includePlannedCancellations: true
-            transitDistanceReluctance: 2000
-          ) {
-            dateTime
-          }
-        }
-        """
+            """
+            {
+              trip(
+                wheelchair: false
+                arriveBy: false
+                includePlannedCancellations: true
+                transitDistanceReluctance: 2000
+              ) {
+                dateTime
+              }
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
 
     func testPutsLargeObjectValuesOnMultipleLinesIfLineIsLong() throws {
-        let document = try parse(source: "{trip(obj:{wheelchair:false,smallObj:{a: 1},largeObj:{wheelchair:false,smallObj:{a: 1},arriveBy:false,includePlannedCancellations:true,transitDistanceReluctance:2000,anotherLongFieldName:\"Lots and lots and lots and lots of text\"},arriveBy:false,includePlannedCancellations:true,transitDistanceReluctance:2000,anotherLongFieldName:\"Lots and lots and lots and lots of text\"}){dateTime}}")
+        let document =
+            try parse(
+                source: "{trip(obj:{wheelchair:false,smallObj:{a: 1},largeObj:{wheelchair:false,smallObj:{a: 1},arriveBy:false,includePlannedCancellations:true,transitDistanceReluctance:2000,anotherLongFieldName:\"Lots and lots and lots and lots of text\"},arriveBy:false,includePlannedCancellations:true,transitDistanceReluctance:2000,anotherLongFieldName:\"Lots and lots and lots and lots of text\"}){dateTime}}"
+            )
         let expected =
-        """
-        {
-          trip(
-            obj: {
-              wheelchair: false
-              smallObj: { a: 1 }
-              largeObj: {
-                wheelchair: false
-                smallObj: { a: 1 }
-                arriveBy: false
-                includePlannedCancellations: true
-                transitDistanceReluctance: 2000
-                anotherLongFieldName: "Lots and lots and lots and lots of text"
+            """
+            {
+              trip(
+                obj: {
+                  wheelchair: false
+                  smallObj: { a: 1 }
+                  largeObj: {
+                    wheelchair: false
+                    smallObj: { a: 1 }
+                    arriveBy: false
+                    includePlannedCancellations: true
+                    transitDistanceReluctance: 2000
+                    anotherLongFieldName: "Lots and lots and lots and lots of text"
+                  }
+                  arriveBy: false
+                  includePlannedCancellations: true
+                  transitDistanceReluctance: 2000
+                  anotherLongFieldName: "Lots and lots and lots and lots of text"
+                }
+              ) {
+                dateTime
               }
-              arriveBy: false
-              includePlannedCancellations: true
-              transitDistanceReluctance: 2000
-              anotherLongFieldName: "Lots and lots and lots and lots of text"
             }
-          ) {
-            dateTime
-          }
-        }
-        """
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
 
     func testPutsLargeListValuesOnMultipleLinesIfLineIsLong() throws {
-        let document = try parse(source: "{trip(list:[[\"small array\", \"small\", \"small\"], [\"Lots and lots and lots and lots of text\", \"Lots and lots and lots and lots of text\", \"Lots and lots and lots and lots of text\"]]){dateTime}}")
+        let document =
+            try parse(
+                source: "{trip(list:[[\"small array\", \"small\", \"small\"], [\"Lots and lots and lots and lots of text\", \"Lots and lots and lots and lots of text\", \"Lots and lots and lots and lots of text\"]]){dateTime}}"
+            )
         let expected =
-        """
-        {
-          trip(
-            list: [
-              ["small array", "small", "small"]
-              [
-                "Lots and lots and lots and lots of text"
-                "Lots and lots and lots and lots of text"
-                "Lots and lots and lots and lots of text"
-              ]
-            ]
-          ) {
-            dateTime
-          }
-        }
-        """
+            """
+            {
+              trip(
+                list: [
+                  ["small array", "small", "small"]
+                  [
+                    "Lots and lots and lots and lots of text"
+                    "Lots and lots and lots and lots of text"
+                    "Lots and lots and lots and lots of text"
+                  ]
+                ]
+              ) {
+                dateTime
+              }
+            }
+            """
         XCTAssertEqual(print(ast: document), expected)
     }
-    
+
     func testPrintsKitchenSinkWithoutAlteringAST() throws {
         guard
             let url = Bundle.module.url(forResource: "kitchen-sink", withExtension: "graphql"),
@@ -167,58 +177,58 @@ class PrinterTests: XCTestCase {
         XCTAssertEqual(document, parsedPrinted)
 
         let expected =
-        """
-        query queryName($foo: ComplexType, $site: Site = MOBILE) {
-          whoever123is: node(id: [123, 456]) {
-            id
-            ... on User @defer {
-              field2 {
+            """
+            query queryName($foo: ComplexType, $site: Site = MOBILE) {
+              whoever123is: node(id: [123, 456]) {
                 id
-                alias: field1(first: 10, after: $foo) @include(if: $foo) {
+                ... on User @defer {
+                  field2 {
+                    id
+                    alias: field1(first: 10, after: $foo) @include(if: $foo) {
+                      id
+                      ...frag
+                    }
+                  }
+                }
+                ... @skip(unless: $foo) {
                   id
-                  ...frag
+                }
+                ... {
+                  id
                 }
               }
             }
-            ... @skip(unless: $foo) {
-              id
-            }
-            ... {
-              id
-            }
-          }
-        }
 
-        mutation likeStory {
-          like(story: 123) @defer {
-            story {
-              id
-            }
-          }
-        }
-
-        subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
-          storyLikeSubscribe(input: $input) {
-            story {
-              likers {
-                count
-              }
-              likeSentence {
-                text
+            mutation likeStory {
+              like(story: 123) @defer {
+                story {
+                  id
+                }
               }
             }
-          }
-        }
 
-        fragment frag on Friend {
-          foo(size: $size, bar: $b, obj: { key: \"value\" })
-        }
+            subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+              storyLikeSubscribe(input: $input) {
+                story {
+                  likers {
+                    count
+                  }
+                  likeSentence {
+                    text
+                  }
+                }
+              }
+            }
 
-        {
-          unnamed(truthy: true, falsey: false)
-          query
-        }
-        """
+            fragment frag on Friend {
+              foo(size: $size, bar: $b, obj: { key: \"value\" })
+            }
+
+            {
+              unnamed(truthy: true, falsey: false)
+              query
+            }
+            """
 
         XCTAssertEqual(printed, expected)
     }

--- a/Tests/GraphQLTests/LanguageTests/PrinterTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/PrinterTests.swift
@@ -1,0 +1,225 @@
+@testable import GraphQL
+import XCTest
+
+class PrinterTests: XCTestCase {
+    func testPrintMinimalAST() {
+        let ast = Name(value: "foo")
+        XCTAssertEqual(print(ast: ast), "foo")
+    }
+
+    func testCorrectlyPrintNonQueryOperationsWithoutNameForQuery() throws {
+        let document = try parse(source: "query { id, name }")
+        let expected =
+        """
+        {
+          id
+          name
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+
+    func testCorrectlyPrintNonQueryOperationsWithoutNameForMutation() throws {
+        let document = try parse(source: "mutation { id, name }")
+        let expected =
+        """
+        mutation {
+          id
+          name
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+    
+    func testCorrectlyPrintNonQueryOperationsWithoutNameForQueryWithArtifacts() throws {
+        let document = try parse(source: "query ($foo: TestType) @testDirective { id, name }")
+        let expected =
+        """
+        query ($foo: TestType) @testDirective {
+          id
+          name
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+
+    func testCorrectlyPrintNonQueryOperationsWithoutNameForMutationWithArtifacts() throws {
+        let document = try parse(source: "mutation ($foo: TestType) @testDirective { id, name }")
+        let expected =
+        """
+        mutation ($foo: TestType) @testDirective {
+          id
+          name
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+
+    // Variable Directives are currently not support by this library
+    // TODO: Add support for variable directives
+//    func testPrintsQueryWithVariableDirectives() throws {
+//        let document = try parse(source: "query ($foo: TestType = { a: 123 } @testDirective(if: true) @test) { id }")
+//        let expected =
+//        """
+//        query ($foo: TestType = { a: 123 } @testDirective(if: true) @test) {
+//          id
+//        }
+//        """
+//        XCTAssertEqual(print(ast: document), expected)
+//    }
+
+    func testKeepsArgumentsOnOneLineIfLineIsShort() throws {
+        let document = try parse(source: "{trip(wheelchair:false arriveBy:false){dateTime}}")
+        let expected =
+        """
+        {
+          trip(wheelchair: false, arriveBy: false) {
+            dateTime
+          }
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+    
+    func testPutsArgumentsOnMultipleLinesIfLineIsLong() throws {
+        let document = try parse(source: "{trip(wheelchair:false arriveBy:false includePlannedCancellations:true transitDistanceReluctance:2000){dateTime}}")
+        let expected =
+        """
+        {
+          trip(
+            wheelchair: false
+            arriveBy: false
+            includePlannedCancellations: true
+            transitDistanceReluctance: 2000
+          ) {
+            dateTime
+          }
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+
+    func testPutsLargeObjectValuesOnMultipleLinesIfLineIsLong() throws {
+        let document = try parse(source: "{trip(obj:{wheelchair:false,smallObj:{a: 1},largeObj:{wheelchair:false,smallObj:{a: 1},arriveBy:false,includePlannedCancellations:true,transitDistanceReluctance:2000,anotherLongFieldName:\"Lots and lots and lots and lots of text\"},arriveBy:false,includePlannedCancellations:true,transitDistanceReluctance:2000,anotherLongFieldName:\"Lots and lots and lots and lots of text\"}){dateTime}}")
+        let expected =
+        """
+        {
+          trip(
+            obj: {
+              wheelchair: false
+              smallObj: { a: 1 }
+              largeObj: {
+                wheelchair: false
+                smallObj: { a: 1 }
+                arriveBy: false
+                includePlannedCancellations: true
+                transitDistanceReluctance: 2000
+                anotherLongFieldName: "Lots and lots and lots and lots of text"
+              }
+              arriveBy: false
+              includePlannedCancellations: true
+              transitDistanceReluctance: 2000
+              anotherLongFieldName: "Lots and lots and lots and lots of text"
+            }
+          ) {
+            dateTime
+          }
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+
+    func testPutsLargeListValuesOnMultipleLinesIfLineIsLong() throws {
+        let document = try parse(source: "{trip(list:[[\"small array\", \"small\", \"small\"], [\"Lots and lots and lots and lots of text\", \"Lots and lots and lots and lots of text\", \"Lots and lots and lots and lots of text\"]]){dateTime}}")
+        let expected =
+        """
+        {
+          trip(
+            list: [
+              ["small array", "small", "small"]
+              [
+                "Lots and lots and lots and lots of text"
+                "Lots and lots and lots and lots of text"
+                "Lots and lots and lots and lots of text"
+              ]
+            ]
+          ) {
+            dateTime
+          }
+        }
+        """
+        XCTAssertEqual(print(ast: document), expected)
+    }
+    
+    func testPrintsKitchenSinkWithoutAlteringAST() throws {
+        guard
+            let url = Bundle.module.url(forResource: "kitchen-sink", withExtension: "graphql"),
+            let kitchenSink = try? String(contentsOf: url)
+        else {
+            XCTFail("Could not load kitchen sink")
+            return
+        }
+
+        let document = try parse(source: kitchenSink)
+        let printed = print(ast: document)
+        let parsedPrinted = try parse(source: printed)
+
+        XCTAssertEqual(document, parsedPrinted)
+
+        let expected =
+        """
+        query queryName($foo: ComplexType, $site: Site = MOBILE) {
+          whoever123is: node(id: [123, 456]) {
+            id
+            ... on User @defer {
+              field2 {
+                id
+                alias: field1(first: 10, after: $foo) @include(if: $foo) {
+                  id
+                  ...frag
+                }
+              }
+            }
+            ... @skip(unless: $foo) {
+              id
+            }
+            ... {
+              id
+            }
+          }
+        }
+
+        mutation likeStory {
+          like(story: 123) @defer {
+            story {
+              id
+            }
+          }
+        }
+
+        subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
+          storyLikeSubscribe(input: $input) {
+            story {
+              likers {
+                count
+              }
+              likeSentence {
+                text
+              }
+            }
+          }
+        }
+
+        fragment frag on Friend {
+          foo(size: $size, bar: $b, obj: { key: \"value\" })
+        }
+
+        {
+          unnamed(truthy: true, falsey: false)
+          query
+        }
+        """
+
+        XCTAssertEqual(printed, expected)
+    }
+}


### PR DESCRIPTION
Ported printer functions from https://github.com/graphql/graphql-js/blob/main/src/language/printer.ts with the goal of using it with federation features. Currently users need to use `.setFederatedSDL(to: <String>)` in the schema builder in Graphiti and this feels like a step toward removing that requirement. 

Still need to port printString and printBlockString functions from the js implementation but that ran into some complications and I would prefer to do that in a future PR. 

I'm still unsure about how to expose this in Graphiti and get the document type to `GraphQLSchema`. 