### PR TITLE
Visitor Fixes and Editing Support

### DIFF
--- a/Sources/GraphQL/Error/GraphQLError.swift
+++ b/Sources/GraphQL/Error/GraphQLError.swift
@@ -197,7 +197,7 @@ extension IndexPath: ExpressibleByArrayLiteral {
     }
 }
 
-public enum IndexPathValue: Codable {
+public enum IndexPathValue: Codable, Equatable {
     case index(Int)
     case key(String)
 
@@ -242,7 +242,7 @@ extension IndexPathValue: CustomStringConvertible {
     }
 }
 
-public protocol IndexPathElement {
+public protocol IndexPathElement: CustomStringConvertible {
     var indexPathValue: IndexPathValue { get }
 }
 

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -2,7 +2,7 @@
  * Contains a range of UTF-8 character offsets and token references that
  * identify the region of the source from which the AST derived.
  */
-public struct Location {
+public struct Location: Equatable {
     /**
      * The character offset at which this Node begins.
      */
@@ -158,6 +158,21 @@ public enum NodeResult {
             return true
         }
         return false
+    }
+
+    func get(key: IndexPathElement) -> NodeResult? {
+        switch self {
+        case let .node(node):
+            guard let key = key.keyValue else {
+                return nil
+            }
+            return node.get(key: key)
+        case let .array(array):
+            guard let key = key.indexValue else {
+                return nil
+            }
+            return .node(array[key])
+        }
     }
 }
 

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -921,6 +921,15 @@ public final class ListValue {
         self.loc = loc
         self.values = values
     }
+
+    public func get(key: String) -> NodeResult? {
+        switch key {
+        case "values":
+            return .array(values)
+        default:
+            return nil
+        }
+    }
 }
 
 extension ListValue: Equatable {
@@ -1007,6 +1016,17 @@ public final class Directive {
         self.name = name
         self.arguments = arguments
     }
+
+    public func get(key: String) -> NodeResult? {
+        switch key {
+        case "name":
+            return .node(name)
+        case "arguments":
+            return .array(arguments)
+        default:
+            return nil
+        }
+    }
 }
 
 extension Directive: Equatable {
@@ -1076,6 +1096,15 @@ public final class ListType {
     init(loc: Location? = nil, type: Type) {
         self.loc = loc
         self.type = type
+    }
+
+    public func get(key: String) -> NodeResult? {
+        switch key {
+        case "type":
+            return .node(type)
+        default:
+            return nil
+        }
     }
 }
 

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -213,7 +213,7 @@ public extension Node {
         return nil
     }
 
-    func set(value: NodeResult?, key: String) {
+    func set(value _: NodeResult?, key _: String) {
         print("TODO: Should be implemented on each type!")
     }
 }
@@ -276,7 +276,7 @@ extension Name: Equatable {
 public final class Document {
     public let kind: Kind = .document
     public let loc: Location?
-    public var definitions: [Definition]
+    public private(set) var definitions: [Definition]
 
     init(loc: Location? = nil, definitions: [Definition]) {
         self.loc = loc
@@ -294,7 +294,7 @@ public final class Document {
             return nil
         }
     }
-    
+
     public func set(value: NodeResult?, key: String) {
         guard let value = value else {
             return
@@ -365,10 +365,10 @@ public final class OperationDefinition {
     public let kind: Kind = .operationDefinition
     public let loc: Location?
     public let operation: OperationType
-    public var name: Name?
-    public var variableDefinitions: [VariableDefinition]
-    public var directives: [Directive]
-    public var selectionSet: SelectionSet
+    public private(set) var name: Name?
+    public private(set) var variableDefinitions: [VariableDefinition]
+    public private(set) var directives: [Directive]
+    public private(set) var selectionSet: SelectionSet
 
     init(
         loc: Location? = nil,
@@ -406,7 +406,7 @@ public final class OperationDefinition {
             return nil
         }
     }
-    
+
     public func set(value: NodeResult?, key: String) {
         guard let value = value else {
             return
@@ -467,9 +467,9 @@ extension OperationDefinition: Hashable {
 public final class VariableDefinition {
     public let kind: Kind = .variableDefinition
     public let loc: Location?
-    public let variable: Variable
-    public let type: Type
-    public let defaultValue: Value?
+    public private(set) var variable: Variable
+    public private(set) var type: Type
+    public private(set) var defaultValue: Value?
 
     init(loc: Location? = nil, variable: Variable, type: Type, defaultValue: Value? = nil) {
         self.loc = loc
@@ -488,6 +488,40 @@ public final class VariableDefinition {
             return defaultValue.map { .node($0) }
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "variable":
+            guard
+                case let .node(node) = value,
+                let variable = node as? Variable
+            else {
+                return
+            }
+            self.variable = variable
+        case "type":
+            guard
+                case let .node(node) = value,
+                let type = node as? Type
+            else {
+                return
+            }
+            self.type = type
+        case "defaultValue":
+            guard
+                case let .node(node) = value,
+                let defaultValue = node as? Value?
+            else {
+                return
+            }
+            self.defaultValue = defaultValue
+        default:
+            return
         }
     }
 }
@@ -517,7 +551,7 @@ extension VariableDefinition: Equatable {
 public final class Variable {
     public let kind: Kind = .variable
     public let loc: Location?
-    public let name: Name
+    public private(set) var name: Name
 
     init(loc: Location? = nil, name: Name) {
         self.loc = loc
@@ -532,6 +566,24 @@ public final class Variable {
             return nil
         }
     }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        default:
+            return
+        }
+    }
 }
 
 extension Variable: Equatable {
@@ -543,7 +595,7 @@ extension Variable: Equatable {
 public final class SelectionSet {
     public let kind: Kind = .selectionSet
     public let loc: Location?
-    public let selections: [Selection]
+    public private(set) var selections: [Selection]
 
     init(loc: Location? = nil, selections: [Selection]) {
         self.loc = loc
@@ -559,6 +611,24 @@ public final class SelectionSet {
             return .array(selections)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "selections":
+            guard
+                case let .array(values) = value,
+                let selections = values as? [Selection]
+            else {
+                return
+            }
+            self.selections = selections
+        default:
+            return
         }
     }
 }
@@ -612,11 +682,11 @@ public func == (lhs: Selection, rhs: Selection) -> Bool {
 public final class Field {
     public let kind: Kind = .field
     public let loc: Location?
-    public let alias: Name?
-    public let name: Name
-    public let arguments: [Argument]
-    public let directives: [Directive]
-    public let selectionSet: SelectionSet?
+    public private(set) var alias: Name?
+    public private(set) var name: Name
+    public private(set) var arguments: [Argument]
+    public private(set) var directives: [Directive]
+    public private(set) var selectionSet: SelectionSet?
 
     init(
         loc: Location? = nil,
@@ -656,6 +726,56 @@ public final class Field {
             return nil
         }
     }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "alias":
+            guard
+                case let .node(node) = value,
+                let alias = node as? Name
+            else {
+                return
+            }
+            self.alias = alias
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        case "arguments":
+            guard
+                case let .array(values) = value,
+                let arguments = values as? [Argument]
+            else {
+                return
+            }
+            self.arguments = arguments
+        case "directives":
+            guard
+                case let .array(values) = value,
+                let directives = values as? [Directive]
+            else {
+                return
+            }
+            self.directives = directives
+        case "selectionSet":
+            guard
+                case let .node(value) = value,
+                let selectionSet = value as? SelectionSet
+            else {
+                return
+            }
+            self.selectionSet = selectionSet
+        default:
+            return
+        }
+    }
 }
 
 extension Field: Equatable {
@@ -671,8 +791,8 @@ extension Field: Equatable {
 public final class Argument {
     public let kind: Kind = .argument
     public let loc: Location?
-    public let name: Name
-    public let value: Value
+    public private(set) var name: Name
+    public private(set) var value: Value
 
     init(loc: Location? = nil, name: Name, value: Value) {
         self.loc = loc
@@ -688,6 +808,32 @@ public final class Argument {
             return .node(value)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        case "value":
+            guard
+                case let .node(node) = value,
+                let value = node as? Value
+            else {
+                return
+            }
+            self.value = value
+        default:
+            return
         }
     }
 }
@@ -706,8 +852,8 @@ extension InlineFragment: Fragment {}
 public final class FragmentSpread {
     public let kind: Kind = .fragmentSpread
     public let loc: Location?
-    public let name: Name
-    public let directives: [Directive]
+    public private(set) var name: Name
+    public private(set) var directives: [Directive]
 
     init(loc: Location? = nil, name: Name, directives: [Directive] = []) {
         self.loc = loc
@@ -726,6 +872,32 @@ public final class FragmentSpread {
             return .array(directives)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        case "directives":
+            guard
+                case let .array(values) = value,
+                let directives = values as? [Directive]
+            else {
+                return
+            }
+            self.directives = directives
+        default:
+            return
         }
     }
 }
@@ -756,9 +928,9 @@ extension FragmentDefinition: HasTypeCondition {
 public final class InlineFragment {
     public let kind: Kind = .inlineFragment
     public let loc: Location?
-    public let typeCondition: NamedType?
-    public let directives: [Directive]
-    public let selectionSet: SelectionSet
+    public private(set) var typeCondition: NamedType?
+    public private(set) var directives: [Directive]
+    public private(set) var selectionSet: SelectionSet
 
     init(
         loc: Location? = nil,
@@ -789,6 +961,40 @@ public extension InlineFragment {
             return nil
         }
     }
+
+    func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "typeCondition":
+            guard
+                case let .node(node) = value,
+                let typeCondition = node as? NamedType
+            else {
+                return
+            }
+            self.typeCondition = typeCondition
+        case "directives":
+            guard
+                case let .array(values) = value,
+                let directives = values as? [Directive]
+            else {
+                return
+            }
+            self.directives = directives
+        case "selectionSet":
+            guard
+                case let .node(value) = value,
+                let selectionSet = value as? SelectionSet
+            else {
+                return
+            }
+            self.selectionSet = selectionSet
+        default:
+            return
+        }
+    }
 }
 
 extension InlineFragment: Equatable {
@@ -802,10 +1008,10 @@ extension InlineFragment: Equatable {
 public final class FragmentDefinition {
     public let kind: Kind = .fragmentDefinition
     public let loc: Location?
-    public let name: Name
-    public let typeCondition: NamedType
-    public let directives: [Directive]
-    public let selectionSet: SelectionSet
+    public private(set) var name: Name
+    public private(set) var typeCondition: NamedType
+    public private(set) var directives: [Directive]
+    public private(set) var selectionSet: SelectionSet
 
     init(
         loc: Location? = nil,
@@ -836,6 +1042,48 @@ public final class FragmentDefinition {
             return .node(selectionSet)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        case "typeCondition":
+            guard
+                case let .node(node) = value,
+                let typeCondition = node as? NamedType
+            else {
+                return
+            }
+            self.typeCondition = typeCondition
+        case "directives":
+            guard
+                case let .array(values) = value,
+                let directives = values as? [Directive]
+            else {
+                return
+            }
+            self.directives = directives
+        case "selectionSet":
+            guard
+                case let .node(value) = value,
+                let selectionSet = value as? SelectionSet
+            else {
+                return
+            }
+            self.selectionSet = selectionSet
+        default:
+            return
         }
     }
 }
@@ -1014,7 +1262,7 @@ extension EnumValue: Equatable {
 public final class ListValue {
     public let kind: Kind = .listValue
     public let loc: Location?
-    public let values: [Value]
+    public private(set) var values: [Value]
 
     init(loc: Location? = nil, values: [Value]) {
         self.loc = loc
@@ -1027,6 +1275,24 @@ public final class ListValue {
             return .array(values)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "values":
+            guard
+                case let .array(values) = value,
+                let values = values as? [Value]
+            else {
+                return
+            }
+            self.values = values
+        default:
+            return
         }
     }
 }
@@ -1050,7 +1316,7 @@ extension ListValue: Equatable {
 public final class ObjectValue {
     public let kind: Kind = .objectValue
     public let loc: Location?
-    public let fields: [ObjectField]
+    public private(set) var fields: [ObjectField]
 
     init(loc: Location? = nil, fields: [ObjectField]) {
         self.loc = loc
@@ -1065,6 +1331,24 @@ public final class ObjectValue {
             return nil
         }
     }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "fields":
+            guard
+                case let .array(values) = value,
+                let fields = values as? [ObjectField]
+            else {
+                return
+            }
+            self.fields = fields
+        default:
+            return
+        }
+    }
 }
 
 extension ObjectValue: Equatable {
@@ -1076,8 +1360,8 @@ extension ObjectValue: Equatable {
 public final class ObjectField {
     public let kind: Kind = .objectField
     public let loc: Location?
-    public let name: Name
-    public let value: Value
+    public private(set) var name: Name
+    public private(set) var value: Value
 
     init(loc: Location? = nil, name: Name, value: Value) {
         self.loc = loc
@@ -1095,6 +1379,32 @@ public final class ObjectField {
             return nil
         }
     }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        case "value":
+            guard
+                case let .node(node) = value,
+                let value = node as? Value
+            else {
+                return
+            }
+            self.value = value
+        default:
+            return
+        }
+    }
 }
 
 extension ObjectField: Equatable {
@@ -1107,8 +1417,8 @@ extension ObjectField: Equatable {
 public final class Directive {
     public let kind: Kind = .directive
     public let loc: Location?
-    public let name: Name
-    public let arguments: [Argument]
+    public private(set) var name: Name
+    public private(set) var arguments: [Argument]
 
     init(loc: Location? = nil, name: Name, arguments: [Argument] = []) {
         self.loc = loc
@@ -1124,6 +1434,32 @@ public final class Directive {
             return .array(arguments)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        case "arguments":
+            guard
+                case let .array(nodes) = value,
+                let arguments = nodes as? [Argument]
+            else {
+                return
+            }
+            self.arguments = arguments
+        default:
+            return
         }
     }
 }
@@ -1164,7 +1500,7 @@ public func == (lhs: Type, rhs: Type) -> Bool {
 public final class NamedType {
     public let kind: Kind = .namedType
     public let loc: Location?
-    public let name: Name
+    public private(set) var name: Name
 
     init(loc: Location? = nil, name: Name) {
         self.loc = loc
@@ -1179,6 +1515,24 @@ public final class NamedType {
             return nil
         }
     }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "name":
+            guard
+                case let .node(node) = value,
+                let name = node as? Name
+            else {
+                return
+            }
+            self.name = name
+        default:
+            return
+        }
+    }
 }
 
 extension NamedType: Equatable {
@@ -1190,7 +1544,7 @@ extension NamedType: Equatable {
 public final class ListType {
     public let kind: Kind = .listType
     public let loc: Location?
-    public let type: Type
+    public private(set) var type: Type
 
     init(loc: Location? = nil, type: Type) {
         self.loc = loc
@@ -1203,6 +1557,24 @@ public final class ListType {
             return .node(type)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "type":
+            guard
+                case let .node(node) = value,
+                let type = node as? Type
+            else {
+                return
+            }
+            self.type = type
+        default:
+            return
         }
     }
 }
@@ -1220,7 +1592,7 @@ extension NamedType: NonNullableType {}
 public final class NonNullType {
     public let kind: Kind = .nonNullType
     public let loc: Location?
-    public let type: NonNullableType
+    public private(set) var type: NonNullableType
 
     init(loc: Location? = nil, type: NonNullableType) {
         self.loc = loc
@@ -1233,6 +1605,24 @@ public final class NonNullType {
             return .node(type)
         default:
             return nil
+        }
+    }
+
+    public func set(value: NodeResult?, key: String) {
+        guard let value = value else {
+            return
+        }
+        switch key {
+        case "type":
+            guard
+                case let .node(node) = value,
+                let type = node as? NonNullableType
+            else {
+                return
+            }
+            self.type = type
+        default:
+            return
         }
     }
 }

--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -213,8 +213,13 @@ public extension Node {
         return nil
     }
 
+    @available(*, deprecated, message: "Use set(value _: NodeResult?, key _: String)")
+    func set(value: Node?, key: String) {
+        return set(value: value.map { .node($0) }, key: key)
+    }
+
     func set(value _: NodeResult?, key _: String) {
-        print("TODO: Should be implemented on each type!")
+        // This should be overridden by each type on which it should do something
     }
 }
 

--- a/Sources/GraphQL/Language/Kinds.swift
+++ b/Sources/GraphQL/Language/Kinds.swift
@@ -1,4 +1,4 @@
-public enum Kind: CaseIterable {
+public enum Kind: String, CaseIterable {
     case name
     case document
     case operationDefinition

--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -183,7 +183,7 @@ func visit(root: Node, visitor: Visitor, keyMap: [Kind: [String]] = [:]) -> Node
                     continue
                 }
             } else if case let .node(resultNode) = result {
-                edits.append((key!, resultNode))
+                edits.append((key ?? "root", resultNode))
                 if !isLeaving {
                     if let resultNode = resultNode {
                         node = .node(resultNode)

--- a/Sources/GraphQL/Language/Visitor.swift
+++ b/Sources/GraphQL/Language/Visitor.swift
@@ -100,7 +100,7 @@ func visit(root: Node, visitor: Visitor, keyMap: [Kind: [String]] = [:]) -> Node
         let isEdited = isLeaving && !edits.isEmpty
 
         if isLeaving {
-            key = ancestors.isEmpty ? nil : path.popLast()
+            key = ancestors.isEmpty ? nil : path.last
             node = parent
             parent = ancestors.popLast()
 

--- a/Tests/GraphQLTests/LanguageTests/VisitorTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/VisitorTests.swift
@@ -8,24 +8,7 @@ class VisitorTests: XCTestCase {
     }
 
     func testValidatesPathArgument() throws {
-        struct VisitedElement: Equatable {
-            let direction: VisitDirection
-            let path: [any IndexPathElement]
-
-            init(_ direction: VisitDirection, _ path: [any IndexPathElement]) {
-                self.direction = direction
-                self.path = path
-            }
-
-            static func == (lhs: VisitedElement, rhs: VisitedElement) -> Bool {
-                return lhs.direction == rhs.direction &&
-                    zip(lhs.path, rhs.path).allSatisfy { lhs, rhs in
-                        lhs.description == rhs.description
-                    }
-            }
-        }
-
-        var visited = [VisitedElement]()
+        var visited = [VisitedPath]()
         let ast = try parse(source: "{ a }", noLocation: true)
 
         visit(root: ast, visitor: .init(
@@ -513,36 +496,7 @@ class VisitorTests: XCTestCase {
     }
 
     func testProperlyVisitsTheKitchenSinkQuery() throws {
-        struct VisitedElement: Equatable, CustomDebugStringConvertible {
-            var debugDescription: String {
-                "(\(direction), \(kind), \(key.debugDescription), \(parentKind.debugDescription))"
-            }
-
-            let direction: VisitDirection
-            let kind: Kind
-            let key: (any IndexPathElement)?
-            let parentKind: Kind?
-
-            init(
-                _ direction: VisitDirection,
-                _ kind: Kind,
-                _ key: (any IndexPathElement)?,
-                _ parentKind: Kind?
-            ) {
-                self.direction = direction
-                self.kind = kind
-                self.key = key
-                self.parentKind = parentKind
-            }
-
-            static func == (lhs: VisitedElement, rhs: VisitedElement) -> Bool {
-                return lhs.direction == rhs.direction &&
-                    lhs.kind == rhs.kind &&
-                    lhs.key?.description == rhs.key?.description &&
-                    lhs.parentKind == rhs.parentKind
-            }
-        }
-        var visited = [VisitedElement]()
+        var visited = [VisitedKindAndParent]()
 
         guard
             let url = Bundle.module.url(forResource: "kitchen-sink", withExtension: "graphql"),

--- a/Tests/GraphQLTests/LanguageTests/VisitorTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/VisitorTests.swift
@@ -2,5 +2,819 @@
 import XCTest
 
 class VisitorTests: XCTestCase {
-    func test() throws {}
+    func testHandlesEmptyVisitor() throws {
+        let ast = try parse(source: "{ a }", noLocation: true)
+        XCTAssertNoThrow(visit(root: ast, visitor: .init()))
+    }
+
+    func testValidatesPathArgument() throws {
+        struct VisitedElement: Equatable {
+            let direction: VisitDirection
+            let path: [any IndexPathElement]
+
+            init(_ direction: VisitDirection, _ path: [any IndexPathElement]) {
+                self.direction = direction
+                self.path = path
+            }
+
+            static func == (lhs: VisitedElement, rhs: VisitedElement) -> Bool {
+                return lhs.direction == rhs.direction &&
+                    zip(lhs.path, rhs.path).allSatisfy { lhs, rhs in
+                        lhs.description == rhs.description
+                    }
+            }
+        }
+
+        var visited = [VisitedElement]()
+        let ast = try parse(source: "{ a }", noLocation: true)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.enter, path))
+                return .continue
+            },
+            leave: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.leave, path))
+                return .continue
+            }
+        ))
+
+        XCTAssertEqual(
+            visited,
+            [
+                .init(.enter, []),
+                .init(.enter, ["definitions", 0]),
+                .init(.enter, ["definitions", 0, "selectionSet"]),
+                .init(.enter, ["definitions", 0, "selectionSet", "selections", 0]),
+                .init(.enter, ["definitions", 0, "selectionSet", "selections", 0, "name"]),
+                .init(.leave, ["definitions", 0, "selectionSet", "selections", 0, "name"]),
+                .init(.leave, ["definitions", 0, "selectionSet", "selections", 0]),
+                .init(.leave, ["definitions", 0, "selectionSet"]),
+                .init(.leave, ["definitions", 0]),
+                .init(.leave, []),
+            ]
+        )
+    }
+
+    func testValidatesAncestorsArgument() throws {
+        var visited = [NodeResult]()
+        let ast = try parse(source: "{ a }", noLocation: true)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, _, parent, _, ancestors in
+                if let parent = parent, parent.isArray {
+                    visited.append(parent)
+                }
+                visited.append(.node(node))
+
+                let expectedAncestors = visited[0 ... max(visited.count - 2, 0)]
+                XCTAssert(zip(ancestors, expectedAncestors).allSatisfy { lhs, rhs in
+                    nodeResultsEqual(lhs, rhs)
+                }, "actual: \(ancestors), expected: \(expectedAncestors)")
+                return .continue
+            },
+            leave: { _, _, parent, _, ancestors in
+                let expectedAncestors = visited[0 ... max(visited.count - 2, 0)]
+                XCTAssert(zip(ancestors, expectedAncestors).allSatisfy { lhs, rhs in
+                    nodeResultsEqual(lhs, rhs)
+                }, "actual: \(ancestors), expected: \(expectedAncestors)")
+
+                if let parent = parent, parent.isArray {
+                    visited.removeLast()
+                }
+                visited.removeLast()
+
+                return .continue
+            }
+        ))
+    }
+    
+    func testAllowsSkippingASubTree() throws {
+        struct VisitedElement: Equatable {
+            let direction: VisitDirection
+            let kind: Kind
+            let value: String?
+
+            init(_ direction: VisitDirection, _ kind: Kind, _ value: String?) {
+                self.direction = direction
+                self.kind = kind
+                self.value = value
+            }
+        }
+
+        var visited = [VisitedElement]()
+        let ast = try parse(source: "{ a, b { x }, c }", noLocation: true)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.enter, node.kind, getValue(node: node)))
+                if let node = node as? Field, node.name.value == "b" {
+                    return .skip
+                }
+                return .continue
+            },
+            leave: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.leave, node.kind, getValue(node: node)))
+                return .continue
+            }
+        ))
+
+        XCTAssertEqual(
+            visited,
+            [
+                .init(.enter, .document, nil),
+                .init(.enter, .operationDefinition, nil),
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "a"),
+                .init(.leave, .name, "a"),
+                .init(.leave, .field, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "c"),
+                .init(.leave, .name, "c"),
+                .init(.leave, .field, nil),
+                .init(.leave, .selectionSet, nil),
+                .init(.leave, .operationDefinition, nil),
+                .init(.leave, .document, nil),
+            ]
+        )
+    }
+
+    func testAllowsEarlyExitWhileVisiting() throws {
+        struct VisitedElement: Equatable {
+            let direction: VisitDirection
+            let kind: Kind
+            let value: String?
+
+            init(_ direction: VisitDirection, _ kind: Kind, _ value: String?) {
+                self.direction = direction
+                self.kind = kind
+                self.value = value
+            }
+        }
+
+        var visited = [VisitedElement]()
+        let ast = try parse(source: "{ a, b { x }, c }", noLocation: true)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.enter, node.kind, getValue(node: node)))
+                if let node = node as? Name, node.value == "x" {
+                    return .break
+                }
+                return .continue
+            },
+            leave: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.leave, node.kind, getValue(node: node)))
+                return .continue
+            }
+        ))
+
+        XCTAssertEqual(
+            visited,
+            [
+                .init(.enter, .document, nil),
+                .init(.enter, .operationDefinition, nil),
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "a"),
+                .init(.leave, .name, "a"),
+                .init(.leave, .field, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "b"),
+                .init(.leave, .name, "b"),
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "x"),
+            ]
+        )
+    }
+
+    func testAllowsEarlyExitWhileLeaving() throws {
+        struct VisitedElement: Equatable {
+            let direction: VisitDirection
+            let kind: Kind
+            let value: String?
+
+            init(_ direction: VisitDirection, _ kind: Kind, _ value: String?) {
+                self.direction = direction
+                self.kind = kind
+                self.value = value
+            }
+        }
+
+        var visited = [VisitedElement]()
+        let ast = try parse(source: "{ a, b { x }, c }", noLocation: true)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.enter, node.kind, getValue(node: node)))
+                return .continue
+            },
+            leave: { node, key, parent, path, ancestors in
+                checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                visited.append(.init(.leave, node.kind, getValue(node: node)))
+                if let node = node as? Name, node.value == "x" {
+                    return .break
+                }
+                return .continue
+            }
+        ))
+
+        XCTAssertEqual(
+            visited,
+            [
+                .init(.enter, .document, nil),
+                .init(.enter, .operationDefinition, nil),
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "a"),
+                .init(.leave, .name, "a"),
+                .init(.leave, .field, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "b"),
+                .init(.leave, .name, "b"),
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .field, nil),
+                .init(.enter, .name, "x"),
+                .init(.leave, .name, "x"),
+            ]
+        )
+    }
+
+    func testAllowsANamedFunctionsVisitorAPI() throws {
+        struct VisitedElement: Equatable {
+            let direction: VisitDirection
+            let kind: Kind
+            let value: String?
+
+            init(_ direction: VisitDirection, _ kind: Kind, _ value: String?) {
+                self.direction = direction
+                self.kind = kind
+                self.value = value
+            }
+        }
+
+        var visited = [VisitedElement]()
+        let ast = try parse(source: "{ a, b { x }, c }", noLocation: true)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, key, parent, path, ancestors in
+                if let node = node as? Name {
+                    checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                    visited.append(.init(.enter, node.kind, getValue(node: node)))
+                }
+                if let node = node as? SelectionSet {
+                    checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                    visited.append(.init(.enter, node.kind, getValue(node: node)))
+                }
+                return .continue
+            },
+            leave: { node, key, parent, path, ancestors in
+                if let node = node as? SelectionSet {
+                    checkVisitorFnArgs(ast, node, key, parent, path, ancestors)
+                    visited.append(.init(.leave, node.kind, getValue(node: node)))
+                }
+                return .continue
+            }
+        ))
+
+        XCTAssertEqual(
+            visited,
+            [
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .name, "a"),
+                .init(.enter, .name, "b"),
+                .init(.enter, .selectionSet, nil),
+                .init(.enter, .name, "x"),
+                .init(.leave, .selectionSet, nil),
+                .init(.enter, .name, "c"),
+                .init(.leave, .selectionSet, nil),
+            ]
+        )
+    }
+
+    func testProperlyVisitsTheKitchenSinkQuery() throws {
+        struct VisitedElement: Equatable, CustomDebugStringConvertible {
+            var debugDescription: String {
+                "(\(direction), \(kind), \(key.debugDescription), \(parentKind.debugDescription))"
+            }
+
+            let direction: VisitDirection
+            let kind: Kind
+            let key: (any IndexPathElement)?
+            let parentKind: Kind?
+
+            init(
+                _ direction: VisitDirection,
+                _ kind: Kind,
+                _ key: (any IndexPathElement)?,
+                _ parentKind: Kind?
+            ) {
+                self.direction = direction
+                self.kind = kind
+                self.key = key
+                self.parentKind = parentKind
+            }
+
+            static func == (lhs: VisitedElement, rhs: VisitedElement) -> Bool {
+                return lhs.direction == rhs.direction &&
+                    lhs.kind == rhs.kind &&
+                    lhs.key?.description == rhs.key?.description &&
+                    lhs.parentKind == rhs.parentKind
+            }
+        }
+        var visited = [VisitedElement]()
+
+        guard
+            let url = Bundle.module.url(forResource: "kitchen-sink", withExtension: "graphql"),
+            let kitchenSink = try? String(contentsOf: url)
+        else {
+            XCTFail("Could not load kitchen sink")
+            return
+        }
+        let ast = try parse(source: kitchenSink)
+
+        visit(root: ast, visitor: .init(
+            enter: { node, key, parent, _, _ in
+                var parentKind: Kind?
+                if case let .node(parent) = parent {
+                    parentKind = parent.kind
+                }
+                visited.append(.init(.enter, node.kind, key, parentKind))
+                return .continue
+            },
+            leave: { node, key, parent, _, _ in
+                var parentKind: Kind?
+                if case let .node(parent) = parent {
+                    parentKind = parent.kind
+                }
+                visited.append(.init(.leave, node.kind, key, parentKind))
+
+                return .continue
+            }
+        ))
+
+        XCTAssertEqual(
+            visited,
+            [
+                .init(.enter, .document, nil, nil),
+                .init(.enter, .operationDefinition, 0, nil),
+                .init(.enter, .name, "name", .operationDefinition),
+                .init(.leave, .name, "name", .operationDefinition),
+                .init(.enter, .variableDefinition, 0, nil),
+                .init(.enter, .variable, "variable", .variableDefinition),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "variable", .variableDefinition),
+                .init(.enter, .namedType, "type", .variableDefinition),
+                .init(.enter, .name, "name", .namedType),
+                .init(.leave, .name, "name", .namedType),
+                .init(.leave, .namedType, "type", .variableDefinition),
+                .init(.leave, .variableDefinition, 0, nil),
+                .init(.enter, .variableDefinition, 1, nil),
+                .init(.enter, .variable, "variable", .variableDefinition),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "variable", .variableDefinition),
+                .init(.enter, .namedType, "type", .variableDefinition),
+                .init(.enter, .name, "name", .namedType),
+                .init(.leave, .name, "name", .namedType),
+                .init(.leave, .namedType, "type", .variableDefinition),
+                .init(.enter, .enumValue, "defaultValue", .variableDefinition),
+                .init(.leave, .enumValue, "defaultValue", .variableDefinition),
+                .init(.leave, .variableDefinition, 1, nil),
+                .init(.enter, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "alias", .field),
+                .init(.leave, .name, "alias", .field),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .listValue, "value", .argument),
+                .init(.enter, .intValue, 0, nil),
+                .init(.leave, .intValue, 0, nil),
+                .init(.enter, .intValue, 1, nil),
+                .init(.leave, .intValue, 1, nil),
+                .init(.leave, .listValue, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.enter, .inlineFragment, 1, nil),
+                .init(.enter, .namedType, "typeCondition", .inlineFragment),
+                .init(.enter, .name, "name", .namedType),
+                .init(.leave, .name, "name", .namedType),
+                .init(.leave, .namedType, "typeCondition", .inlineFragment),
+                .init(.enter, .directive, 0, nil),
+                .init(.enter, .name, "name", .directive),
+                .init(.leave, .name, "name", .directive),
+                .init(.leave, .directive, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .inlineFragment),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.enter, .field, 1, nil),
+                .init(.enter, .name, "alias", .field),
+                .init(.leave, .name, "alias", .field),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .intValue, "value", .argument),
+                .init(.leave, .intValue, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.enter, .argument, 1, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .variable, "value", .argument),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "value", .argument),
+                .init(.leave, .argument, 1, nil),
+                .init(.enter, .directive, 0, nil),
+                .init(.enter, .name, "name", .directive),
+                .init(.leave, .name, "name", .directive),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .variable, "value", .argument),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.leave, .directive, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.enter, .fragmentSpread, 1, nil),
+                .init(.enter, .name, "name", .fragmentSpread),
+                .init(.leave, .name, "name", .fragmentSpread),
+                .init(.leave, .fragmentSpread, 1, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 1, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .inlineFragment),
+                .init(.leave, .inlineFragment, 1, nil),
+                .init(.enter, .inlineFragment, 2, nil),
+                .init(.enter, .directive, 0, nil),
+                .init(.enter, .name, "name", .directive),
+                .init(.leave, .name, "name", .directive),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .variable, "value", .argument),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.leave, .directive, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .inlineFragment),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .inlineFragment),
+                .init(.leave, .inlineFragment, 2, nil),
+                .init(.enter, .inlineFragment, 3, nil),
+                .init(.enter, .selectionSet, "selectionSet", .inlineFragment),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .inlineFragment),
+                .init(.leave, .inlineFragment, 3, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.leave, .operationDefinition, 0, nil),
+                .init(.enter, .operationDefinition, 1, nil),
+                .init(.enter, .name, "name", .operationDefinition),
+                .init(.leave, .name, "name", .operationDefinition),
+                .init(.enter, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .intValue, "value", .argument),
+                .init(.leave, .intValue, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.enter, .directive, 0, nil),
+                .init(.enter, .name, "name", .directive),
+                .init(.leave, .name, "name", .directive),
+                .init(.leave, .directive, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.leave, .operationDefinition, 1, nil),
+                .init(.enter, .operationDefinition, 2, nil),
+                .init(.enter, .name, "name", .operationDefinition),
+                .init(.leave, .name, "name", .operationDefinition),
+                .init(.enter, .variableDefinition, 0, nil),
+                .init(.enter, .variable, "variable", .variableDefinition),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "variable", .variableDefinition),
+                .init(.enter, .namedType, "type", .variableDefinition),
+                .init(.enter, .name, "name", .namedType),
+                .init(.leave, .name, "name", .namedType),
+                .init(.leave, .namedType, "type", .variableDefinition),
+                .init(.leave, .variableDefinition, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .variable, "value", .argument),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.enter, .field, 1, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .selectionSet, "selectionSet", .field),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 1, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .field),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.leave, .operationDefinition, 2, nil),
+                .init(.enter, .fragmentDefinition, 3, nil),
+                .init(.enter, .name, "name", .fragmentDefinition),
+                .init(.leave, .name, "name", .fragmentDefinition),
+                .init(.enter, .namedType, "typeCondition", .fragmentDefinition),
+                .init(.enter, .name, "name", .namedType),
+                .init(.leave, .name, "name", .namedType),
+                .init(.leave, .namedType, "typeCondition", .fragmentDefinition),
+                .init(.enter, .selectionSet, "selectionSet", .fragmentDefinition),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .variable, "value", .argument),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.enter, .argument, 1, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .variable, "value", .argument),
+                .init(.enter, .name, "name", .variable),
+                .init(.leave, .name, "name", .variable),
+                .init(.leave, .variable, "value", .argument),
+                .init(.leave, .argument, 1, nil),
+                .init(.enter, .argument, 2, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .objectValue, "value", .argument),
+                .init(.enter, .objectField, 0, nil),
+                .init(.enter, .name, "name", .objectField),
+                .init(.leave, .name, "name", .objectField),
+                .init(.enter, .stringValue, "value", .objectField),
+                .init(.leave, .stringValue, "value", .objectField),
+                .init(.leave, .objectField, 0, nil),
+                .init(.leave, .objectValue, "value", .argument),
+                .init(.leave, .argument, 2, nil),
+                .init(.leave, .field, 0, nil),
+                .init(.leave, .selectionSet, "selectionSet", .fragmentDefinition),
+                .init(.leave, .fragmentDefinition, 3, nil),
+                .init(.enter, .operationDefinition, 4, nil),
+                .init(.enter, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.enter, .field, 0, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.enter, .argument, 0, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .booleanValue, "value", .argument),
+                .init(.leave, .booleanValue, "value", .argument),
+                .init(.leave, .argument, 0, nil),
+                .init(.enter, .argument, 1, nil),
+                .init(.enter, .name, "name", .argument),
+                .init(.leave, .name, "name", .argument),
+                .init(.enter, .booleanValue, "value", .argument),
+                .init(.leave, .booleanValue, "value", .argument),
+                .init(.leave, .argument, 1, nil),
+                .init(.leave, .field, 0, nil),
+                .init(.enter, .field, 1, nil),
+                .init(.enter, .name, "name", .field),
+                .init(.leave, .name, "name", .field),
+                .init(.leave, .field, 1, nil),
+                .init(.leave, .selectionSet, "selectionSet", .operationDefinition),
+                .init(.leave, .operationDefinition, 4, nil),
+                .init(.leave, .document, nil, nil),
+            ]
+        )
+    }
+}
+
+enum VisitDirection: Equatable {
+    case enter
+    case leave
+}
+
+struct VisitedPath {
+    let direction: VisitDirection
+    let path: [IndexPathElement]
+
+    init(_ direction: VisitDirection, _ path: [IndexPathElement]) {
+        self.direction = direction
+        self.path = path
+    }
+}
+
+extension VisitedPath: Equatable {
+    static func == (lhs: VisitedPath, rhs: VisitedPath) -> Bool {
+        return lhs.direction == rhs.direction &&
+            zip(lhs.path, rhs.path).allSatisfy { lhs, rhs in
+                lhs.description == rhs.description
+            }
+    }
+}
+
+struct VisitedKindAndParent {
+    let direction: VisitDirection
+    let kind: Kind
+    let key: IndexPathElement?
+    let parentKind: Kind?
+
+    init(
+        _ direction: VisitDirection,
+        _ kind: Kind,
+        _ key: IndexPathElement?,
+        _ parentKind: Kind?
+    ) {
+        self.direction = direction
+        self.kind = kind
+        self.key = key
+        self.parentKind = parentKind
+    }
+}
+
+extension VisitedKindAndParent: Equatable {
+    static func == (lhs: VisitedKindAndParent, rhs: VisitedKindAndParent) -> Bool {
+        return lhs.direction == rhs.direction &&
+            lhs.kind == rhs.kind &&
+            lhs.key?.description == rhs.key?.description &&
+            lhs.parentKind == rhs.parentKind
+    }
+}
+
+extension VisitedKindAndParent: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "(\(direction), \(kind), \(key.debugDescription), \(parentKind.debugDescription))"
+    }
+}
+
+func checkVisitorFnArgs(
+    _ ast: Document,
+    _ node: Node,
+    _ key: IndexPathElement?,
+    _ parent: NodeResult?,
+    _ path: [IndexPathElement],
+    _ ancestors: [NodeResult],
+    isEdited: Bool = false
+) {
+    guard let key = key else {
+        if !isEdited {
+            guard let node = node as? Document else {
+                XCTFail()
+                return
+            }
+            XCTAssertEqual(node, ast)
+        }
+        XCTAssertNil(parent)
+        XCTAssert(path.isEmpty)
+        XCTAssert(ancestors.isEmpty)
+        return
+    }
+    XCTAssertEqual(path.last?.indexPathValue, key.indexPathValue)
+    XCTAssertEqual(ancestors.count, path.count - 1)
+
+    if !isEdited {
+        var currentNode = NodeResult.node(ast)
+        for (index, ancestor) in ancestors.enumerated() {
+            XCTAssert(nodeResultsEqual(ancestor, currentNode))
+            guard let nextNode = currentNode.get(key: path[index]) else {
+                XCTFail()
+                return
+            }
+            currentNode = nextNode
+        }
+        guard let parent = parent else {
+            XCTFail()
+            return
+        }
+        XCTAssert(nodeResultsEqual(parent, currentNode))
+        guard let parentNode = parent.get(key: key) else {
+            XCTFail()
+            return
+        }
+        XCTAssert(nodeResultsEqual(parentNode, .node(node)))
+    }
+}
+
+func nodeResultsEqual(_ n1: NodeResult, _ n2: NodeResult) -> Bool {
+    switch n1 {
+    case let .node(n1):
+        switch n2 {
+        case let .node(n2):
+            return n1.kind == n2.kind && n1.loc == n2.loc
+        default:
+            return false
+        }
+    case let .array(n1):
+        switch n2 {
+        case let .array(n2):
+            return zip(n1, n2).allSatisfy { n1, n2 in
+                nodesEqual(n1, n2)
+            }
+        default:
+            return false
+        }
+    }
+}
+
+func nodesEqual(_ n1: Node, _ n2: Node) -> Bool {
+    return n1.kind == n2.kind && n1.loc == n2.loc
+}
+
+func getValue(node: Node) -> String? {
+    switch node {
+    case let node as IntValue:
+        return node.value
+    case let node as FloatValue:
+        return node.value
+    case let node as StringValue:
+        return node.value
+    case let node as BooleanValue:
+        return node.value.description
+    case let node as EnumValue:
+        return node.value
+    case let node as Name:
+        return node.value
+    default:
+        return nil
+    }
 }


### PR DESCRIPTION
This adds editing support to the AST Visitor system. In addition, it also:

- Adds all graphql-js visitor tests cases, both for editing and for normal visitor operation
- Fixes a bug where the Visitor would not visit all Directive, ListType, or ListValue properties
- Fixes a bug where Visitor path would be generated incorrectly
- Improves Visitor null safety