### PR TITLE
Fixes Parser & Printer for SDL Functionality

### DIFF
--- a/Sources/GraphQL/Language/BlockString.swift
+++ b/Sources/GraphQL/Language/BlockString.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/**
+ * Print a block string in the indented block form by adding a leading and
+ * trailing blank line. However, if a block string starts with whitespace and is
+ * a single-line, adding a leading blank line would strip that whitespace.
+ *
+ * @internal
+ */
+func printBlockString(
+    _ value: String,
+    minimize: Bool = false
+) -> String {
+    let escapedValue = value.replacingOccurrences(of: "\"\"\"", with: "\\\"\"\"")
+
+    // Expand a block string's raw value into independent lines.
+    let lines = splitLines(string: escapedValue)
+    let isSingleLine = lines.count == 1
+
+    // If common indentation is found we can fix some of those cases by adding leading new line
+    let forceLeadingNewLine =
+        lines.count > 1 &&
+        lines[1 ... (lines.count - 1)].allSatisfy { line in
+            line.count == 0 || isWhiteSpace(line.charCode(at: 0))
+        }
+
+    // Trailing triple quotes just looks confusing but doesn't force trailing new line
+    let hasTrailingTripleQuotes = escapedValue.hasSuffix("\\\"\"\"")
+
+    // Trailing quote (single or double) or slash forces trailing new line
+    let hasTrailingQuote = value.hasSuffix("\"") && !hasTrailingTripleQuotes
+    let hasTrailingSlash = value.hasSuffix("\\")
+    let forceTrailingNewline = hasTrailingQuote || hasTrailingSlash
+
+    let printAsMultipleLines =
+        !minimize &&
+        // add leading and trailing new lines only if it improves readability
+        (
+            !isSingleLine ||
+                value.count > 70 ||
+                forceTrailingNewline ||
+                forceLeadingNewLine ||
+                hasTrailingTripleQuotes
+        )
+
+    var result = ""
+
+    // Format a multi-line block quote to account for leading space.
+    let skipLeadingNewLine = isSingleLine && isWhiteSpace(value.charCode(at: 0))
+    if (printAsMultipleLines && !skipLeadingNewLine) || forceLeadingNewLine {
+        result += "\n"
+    }
+
+    result += escapedValue
+    if printAsMultipleLines || forceTrailingNewline {
+        result += "\n"
+    }
+
+    return "\"\"\"" + result + "\"\"\""
+}

--- a/Sources/GraphQL/Language/CharacterClasses.swift
+++ b/Sources/GraphQL/Language/CharacterClasses.swift
@@ -1,0 +1,14 @@
+/**
+ * ```
+ * WhiteSpace ::
+ *   - "Horizontal Tab (U+0009)"
+ *   - "Space (U+0020)"
+ * ```
+ * @internal
+ */
+func isWhiteSpace(_ code: UInt8?) -> Bool {
+    guard let code = code else {
+        return false
+    }
+    return code == 0x0009 || code == 0x0020
+}

--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -1038,16 +1038,28 @@ func parseTypeExtensionDefinition(lexer: Lexer) throws -> TypeExtensionDefinitio
 func parseSchemaExtensionDefinition(lexer: Lexer) throws -> SchemaExtensionDefinition {
     let start = lexer.token
     try expectKeyword(lexer: lexer, value: "extend")
-    let description = try parseDescription(lexer: lexer)
     try expectKeyword(lexer: lexer, value: "schema")
     let directives = try parseDirectives(lexer: lexer)
+    let operationTypes = try optionalMany(
+        lexer: lexer,
+        openKind: .openingBrace,
+        closeKind: .closingBrace,
+        parse: parseOperationTypeDefinition
+    )
+    if directives.isEmpty, operationTypes.isEmpty {
+        throw syntaxError(
+            source: lexer.source,
+            position: lexer.token.start,
+            description: "expected schema extend to have directive or operation"
+        )
+    }
     return SchemaExtensionDefinition(
         loc: loc(lexer: lexer, startToken: start),
         definition: SchemaDefinition(
             loc: loc(lexer: lexer, startToken: start),
-            description: description,
+            description: nil,
             directives: directives,
-            operationTypes: []
+            operationTypes: operationTypes
         )
     )
 }

--- a/Sources/GraphQL/Language/PrintString.swift
+++ b/Sources/GraphQL/Language/PrintString.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/**
+ * Prints a string as a GraphQL StringValue literal. Replaces control characters
+ * and excluded characters (" U+0022 and \\ U+005C) with escape sequences.
+ */
+func printString(_ str: String) -> String {
+    let replacedString = str.unicodeScalars.map { char in
+        if
+            char.value <= 0x1F || // \x00-\x1f
+            char.value == 0x22 || // \x22
+            char.value == 0x5C || // \x5c
+            (char.value >= 0x7F && char.value <= 0x9F) // \x7f-\x9f
+        {
+            return escapeSequences[Int(char.value)]
+        }
+        return String(char)
+    }.joined()
+    return "\"\(replacedString)\""
+}
+
+let escapeSequences = [
+    "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005", "\\u0006", "\\u0007",
+    "\\b", "\\t", "\\n", "\\u000B", "\\f", "\\r", "\\u000E", "\\u000F",
+    "\\u0010", "\\u0011", "\\u0012", "\\u0013", "\\u0014", "\\u0015", "\\u0016", "\\u0017",
+    "\\u0018", "\\u0019", "\\u001A", "\\u001B", "\\u001C", "\\u001D", "\\u001E", "\\u001F",
+    "", "", "\\\"", "", "", "", "", "",
+    "", "", "", "", "", "", "", "", // 2F
+    "", "", "", "", "", "", "", "",
+    "", "", "", "", "", "", "", "", // 3F
+    "", "", "", "", "", "", "", "",
+    "", "", "", "", "", "", "", "", // 4F
+    "", "", "", "", "", "", "", "",
+    "", "", "", "", "\\\\", "", "", "", // 5F
+    "", "", "", "", "", "", "", "",
+    "", "", "", "", "", "", "", "", // 6F
+    "", "", "", "", "", "", "", "",
+    "", "", "", "", "", "", "", "\\u007F",
+    "\\u0080", "\\u0081", "\\u0082", "\\u0083", "\\u0084", "\\u0085", "\\u0086", "\\u0087",
+    "\\u0088", "\\u0089", "\\u008A", "\\u008B", "\\u008C", "\\u008D", "\\u008E", "\\u008F",
+    "\\u0090", "\\u0091", "\\u0092", "\\u0093", "\\u0094", "\\u0095", "\\u0096", "\\u0097",
+    "\\u0098", "\\u0099", "\\u009A", "\\u009B", "\\u009C", "\\u009D", "\\u009E", "\\u009F",
+]

--- a/Sources/GraphQL/Language/Printer.swift
+++ b/Sources/GraphQL/Language/Printer.swift
@@ -141,8 +141,7 @@ extension FloatValue: Printable {
 
 extension StringValue: Printable {
     var printed: String {
-        block == true ? value : "\"\(value)\""
-        // TODO: isBlockString === true ? printBlockString(value) : printString(value),
+        block == true ? printBlockString(value) : printString(value)
     }
 }
 

--- a/Tests/GraphQLTests/LanguageTests/BlockStringTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/BlockStringTests.swift
@@ -1,0 +1,75 @@
+@testable import GraphQL
+import XCTest
+
+class PrintBlockStringTests: XCTestCase {
+    func testDoesNotEscapeCharacters() {
+        let str = "\" \\ / \n \r \t"
+        XCTAssertEqual(printBlockString(str), "\"\"\"\n" + str + "\n\"\"\"")
+        XCTAssertEqual(printBlockString(str, minimize: true), "\"\"\"\n" + str + "\"\"\"")
+    }
+
+    func testByDefaultPrintBlockStringsAsSingleLine() {
+        XCTAssertEqual(printBlockString("one liner"), "\"\"\"one liner\"\"\"")
+    }
+
+    func testByDefaultPrintBlockStringsEndingWithTripleQuotationAsMultiLine() {
+        let str = "triple quotation \"\"\""
+        XCTAssertEqual(printBlockString(str), "\"\"\"\ntriple quotation \\\"\"\"\n\"\"\"")
+        XCTAssertEqual(
+            printBlockString(str, minimize: true),
+            "\"\"\"triple quotation \\\"\"\"\"\"\""
+        )
+    }
+
+    func testCorrectlyPrintsSingleLineWithLeadingSpace() {
+        XCTAssertEqual(
+            printBlockString("    space-led value \"quoted string\""),
+            "\"\"\"    space-led value \"quoted string\"\n\"\"\""
+        )
+    }
+
+    func testCorrectlyPrintsSingleLineWithTrailingBackslash() {
+        let str = "backslash \\"
+        XCTAssertEqual(printBlockString(str), "\"\"\"\nbackslash \\\n\"\"\"")
+        XCTAssertEqual(printBlockString(str, minimize: true), "\"\"\"backslash \\\n\"\"\"")
+    }
+
+    func testCorrectlyPrintsMultiLineWithInternalIndent() {
+        let str = "no indent\n with indent"
+        XCTAssertEqual(printBlockString(str), "\"\"\"\nno indent\n with indent\n\"\"\"")
+        XCTAssertEqual(
+            printBlockString(str, minimize: true),
+            "\"\"\"\nno indent\n with indent\"\"\""
+        )
+    }
+
+    func testCorrectlyPrintsStringWithAFirstLineIndentation() {
+        let str = [
+            "    first  ",
+            "  line     ",
+            "indentation",
+            "     string",
+        ].joined(separator: "\n")
+
+        XCTAssertEqual(
+            printBlockString(str),
+            [
+                "\"\"\"",
+                "    first  ",
+                "  line     ",
+                "indentation",
+                "     string",
+                "\"\"\"",
+            ].joined(separator: "\n")
+        )
+        XCTAssertEqual(
+            printBlockString(str, minimize: true),
+            [
+                "\"\"\"    first  ",
+                "  line     ",
+                "indentation",
+                "     string\"\"\"",
+            ].joined(separator: "\n")
+        )
+    }
+}

--- a/Tests/GraphQLTests/LanguageTests/PrintStringTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/PrintStringTests.swift
@@ -1,0 +1,75 @@
+@testable import GraphQL
+import XCTest
+
+class PrintStringTests: XCTestCase {
+    func testPrintsASimpleString() {
+        XCTAssertEqual(printString("hello world"), "\"hello world\"")
+    }
+
+    func testEscapesQutoes() {
+        XCTAssertEqual(printString("\"hello world\""), "\"\\\"hello world\\\"\"")
+    }
+
+    func testDoesNotEscapeSingleQuote() {
+        XCTAssertEqual(printString("who's test"), "\"who's test\"")
+    }
+
+    func testEscapesBackslashes() {
+        XCTAssertEqual(printString("escape: \\"), "\"escape: \\\\\"")
+    }
+
+    func testEscapesWellKnownControlChars() {
+        XCTAssertEqual(printString("\n\r\t"), "\"\\n\\r\\t\"")
+    }
+
+    func testEscapesZeroByte() {
+        XCTAssertEqual(printString("\u{0000}"), "\"\\u0000\"")
+    }
+
+    func testDoesNotEscapeSpace() {
+        XCTAssertEqual(printString(" "), "\" \"")
+    }
+
+    // TODO: We only support UTF8
+    func testDoesNotEscapeSupplementaryCharacter() {
+        XCTAssertEqual(printString("\u{1f600}"), "\"\u{1f600}\"")
+    }
+
+    func testEscapesAllControlChars() {
+        XCTAssertEqual(
+            printString(
+                "\u{0000}\u{0001}\u{0002}\u{0003}\u{0004}\u{0005}\u{0006}\u{0007}" +
+                    "\u{0008}\u{0009}\u{000A}\u{000B}\u{000C}\u{000D}\u{000E}\u{000F}" +
+                    "\u{0010}\u{0011}\u{0012}\u{0013}\u{0014}\u{0015}\u{0016}\u{0017}" +
+                    "\u{0018}\u{0019}\u{001A}\u{001B}\u{001C}\u{001D}\u{001E}\u{001F}" +
+                    "\u{0020}\u{0021}\u{0022}\u{0023}\u{0024}\u{0025}\u{0026}\u{0027}" +
+                    "\u{0028}\u{0029}\u{002A}\u{002B}\u{002C}\u{002D}\u{002E}\u{002F}" +
+                    "\u{0030}\u{0031}\u{0032}\u{0033}\u{0034}\u{0035}\u{0036}\u{0037}" +
+                    "\u{0038}\u{0039}\u{003A}\u{003B}\u{003C}\u{003D}\u{003E}\u{003F}" +
+                    "\u{0040}\u{0041}\u{0042}\u{0043}\u{0044}\u{0045}\u{0046}\u{0047}" +
+                    "\u{0048}\u{0049}\u{004A}\u{004B}\u{004C}\u{004D}\u{004E}\u{004F}" +
+                    "\u{0050}\u{0051}\u{0052}\u{0053}\u{0054}\u{0055}\u{0056}\u{0057}" +
+                    "\u{0058}\u{0059}\u{005A}\u{005B}\u{005C}\u{005D}\u{005E}\u{005F}" +
+                    "\u{0060}\u{0061}\u{0062}\u{0063}\u{0064}\u{0065}\u{0066}\u{0067}" +
+                    "\u{0068}\u{0069}\u{006A}\u{006B}\u{006C}\u{006D}\u{006E}\u{006F}" +
+                    "\u{0070}\u{0071}\u{0072}\u{0073}\u{0074}\u{0075}\u{0076}\u{0077}" +
+                    "\u{0078}\u{0079}\u{007A}\u{007B}\u{007C}\u{007D}\u{007E}\u{007F}" +
+                    "\u{0080}\u{0081}\u{0082}\u{0083}\u{0084}\u{0085}\u{0086}\u{0087}" +
+                    "\u{0088}\u{0089}\u{008A}\u{008B}\u{008C}\u{008D}\u{008E}\u{008F}" +
+                    "\u{0090}\u{0091}\u{0092}\u{0093}\u{0094}\u{0095}\u{0096}\u{0097}" +
+                    "\u{0098}\u{0099}\u{009A}\u{009B}\u{009C}\u{009D}\u{009E}\u{009F}"
+            ),
+            "\"\\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007" +
+                "\\b\\t\\n\\u000B\\f\\r\\u000E\\u000F" +
+                "\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017" +
+                "\\u0018\\u0019\\u001A\\u001B\\u001C\\u001D\\u001E\\u001F" +
+                " !\\\"#$%&\'()*+,-./0123456789:;<=>?" +
+                "@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\\]^_" +
+                "`abcdefghijklmnopqrstuvwxyz{|}~\\u007F" +
+                "\\u0080\\u0081\\u0082\\u0083\\u0084\\u0085\\u0086\\u0087" +
+                "\\u0088\\u0089\\u008A\\u008B\\u008C\\u008D\\u008E\\u008F" +
+                "\\u0090\\u0091\\u0092\\u0093\\u0094\\u0095\\u0096\\u0097" +
+                "\\u0098\\u0099\\u009A\\u009B\\u009C\\u009D\\u009E\\u009F\""
+        )
+    }
+}

--- a/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaParserTests.swift
@@ -111,6 +111,63 @@ class SchemaParserTests: XCTestCase {
         XCTAssert(result == expected)
     }
 
+    func testParsesTypeWithDescriptionString() throws {
+        let doc = try parse(source: """
+        "Description"
+        type Hello {
+          world: String
+        }
+        """)
+
+        let type = try XCTUnwrap(doc.definitions[0] as? ObjectTypeDefinition)
+
+        XCTAssertEqual(
+            type.description?.value,
+            "Description"
+        )
+    }
+
+    func testParsesTypeWithDescriptionMultiLineString() throws {
+        let doc = try parse(source: #"""
+        """
+        Description
+        """
+        # Even with comments between them
+        type Hello {
+          world: String
+        }
+        """#)
+
+        let type = try XCTUnwrap(doc.definitions[0] as? ObjectTypeDefinition)
+
+        XCTAssertEqual(
+            type.description?.value,
+            "Description"
+        )
+    }
+
+    func testParsesSchemaWithDescriptionMultiLineString() throws {
+        let doc = try parse(source: """
+        "Description"
+        schema {
+          query: Foo
+        }
+        """)
+
+        let type = try XCTUnwrap(doc.definitions[0] as? SchemaDefinition)
+
+        XCTAssertEqual(
+            type.description?.value,
+            "Description"
+        )
+    }
+
+    func testDescriptionFollowedBySomethingOtherThanTypeSystemDefinitionThrows() throws {
+        XCTAssertThrowsError(
+            try parse(source: #""Description" 1"#)
+        )
+    }
+
     func testSchemeExtension() throws {
         // Based on Apollo Federation example schema: https://github.com/apollographql/apollo-federation-subgraph-compatibility/blob/main/COMPATIBILITY.md#products-schema-to-be-implemented-by-library-maintainers
         let source =

--- a/Tests/GraphQLTests/LanguageTests/SchemaPrinterTests.swift
+++ b/Tests/GraphQLTests/LanguageTests/SchemaPrinterTests.swift
@@ -1,0 +1,174 @@
+@testable import GraphQL
+import XCTest
+
+class SchemaPrinterTests: XCTestCase {
+    func testPrintsMinimalAST() {
+        let ast = ScalarTypeDefinition(
+            name: .init(value: "foo")
+        )
+        XCTAssertEqual(print(ast: ast), "scalar foo")
+    }
+
+    func testPrintsKitchenSinkWithoutAlteringAST() throws {
+        guard
+            let url = Bundle.module.url(
+                forResource: "schema-kitchen-sink",
+                withExtension: "graphql"
+            ),
+            let kitchenSink = try? String(contentsOf: url)
+        else {
+            XCTFail("Could not load kitchen sink")
+            return
+        }
+
+        let ast = try parse(source: kitchenSink, noLocation: true)
+
+        let printed = print(ast: ast)
+        let printedAST = try parse(source: printed, noLocation: true)
+
+        XCTAssertEqual(printed, print(ast: printedAST))
+        XCTAssertEqual(printed, #"""
+        """This is a description of the schema as a whole."""
+        schema {
+          query: QueryType
+          mutation: MutationType
+        }
+
+        """
+        This is a description
+        of the `Foo` type.
+        """
+        type Foo implements Bar & Baz & Two {
+          "Description of the `one` field."
+          one: Type
+          """This is a description of the `two` field."""
+          two(
+            """This is a description of the `argument` argument."""
+            argument: InputType!
+          ): Type
+          """This is a description of the `three` field."""
+          three(argument: InputType, other: String): Int
+          four(argument: String = "string"): String
+          five(argument: [String] = ["string", "string"]): String
+          six(argument: InputType = { key: "value" }): Type
+          seven(argument: Int = null): Type
+          eight(argument: OneOfInputType): Type
+        }
+
+        type AnnotatedObject @onObject(arg: "value") {
+          annotatedField(arg: Type = "default" @onArgumentDefinition): Type @onField
+        }
+
+        type UndefinedType
+
+        extend type Foo {
+          seven(argument: [String]): Type
+        }
+
+        extend type Foo @onType
+
+        interface Bar {
+          one: Type
+          four(argument: String = "string"): String
+        }
+
+        interface AnnotatedInterface @onInterface {
+          annotatedField(arg: Type @onArgumentDefinition): Type @onField
+        }
+
+        interface UndefinedInterface
+
+        extend interface Bar implements Two {
+          two(argument: InputType!): Type
+        }
+
+        extend interface Bar @onInterface
+
+        interface Baz implements Bar & Two {
+          one: Type
+          two(argument: InputType!): Type
+          four(argument: String = "string"): String
+        }
+
+        union Feed = Story | Article | Advert
+
+        union AnnotatedUnion @onUnion = A | B
+
+        union AnnotatedUnionTwo @onUnion = A | B
+
+        union UndefinedUnion
+
+        extend union Feed = Photo | Video
+
+        extend union Feed @onUnion
+
+        scalar CustomScalar
+
+        scalar AnnotatedScalar @onScalar
+
+        extend scalar CustomScalar @onScalar
+
+        enum Site {
+          """This is a description of the `DESKTOP` value"""
+          DESKTOP
+          """This is a description of the `MOBILE` value"""
+          MOBILE
+          "This is a description of the `WEB` value"
+          WEB
+        }
+
+        enum AnnotatedEnum @onEnum {
+          ANNOTATED_VALUE @onEnumValue
+          OTHER_VALUE
+        }
+
+        enum UndefinedEnum
+
+        extend enum Site {
+          VR
+        }
+
+        extend enum Site @onEnum
+
+        input InputType {
+          key: String!
+          answer: Int = 42
+        }
+
+        input OneOfInputType @oneOf {
+          string: String
+          int: Int
+        }
+
+        input AnnotatedInput @onInputObject {
+          annotatedField: Type @onInputFieldDefinition
+        }
+
+        input UndefinedInput
+
+        extend input InputType {
+          other: Float = 1.23e4 @onInputFieldDefinition
+        }
+
+        extend input InputType @onInputObject
+
+        """This is a description of the `@skip` directive"""
+        directive @skip(
+          """This is a description of the `if` argument"""
+          if: Boolean! @onArgumentDefinition
+        ) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+        directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+        directive @include2(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+        directive @myRepeatableDir(name: String!) repeatable on OBJECT | INTERFACE
+
+        extend schema @onSchema
+
+        extend schema @onSchema {
+          subscription: SubscriptionType
+        }
+        """#)
+    }
+}

--- a/Tests/GraphQLTests/LanguageTests/schema-kitchen-sink.graphql
+++ b/Tests/GraphQLTests/LanguageTests/schema-kitchen-sink.graphql
@@ -1,10 +1,4 @@
-# Copyright (c) 2015, Facebook, Inc.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
-
+"""This is a description of the schema as a whole."""
 schema {
   query: QueryType
   mutation: MutationType
@@ -32,6 +26,7 @@ type Foo implements Bar & Baz & Two {
   five(argument: [String] = ["string", "string"]): String
   six(argument: InputType = {key: "value"}): Type
   seven(argument: Int = null): Type
+  eight(argument: OneOfInputType): Type
 }
 
 type AnnotatedObject @onObject(arg: "value") {
@@ -119,6 +114,11 @@ extend enum Site @onEnum
 input InputType {
   key: String!
   answer: Int = 42
+}
+
+input OneOfInputType @oneOf {
+  string: String
+  int: Int
 }
 
 input AnnotatedInput @onInputObject {


### PR DESCRIPTION
This makes the following minor fixes to the Printer and Parser to support SDL functionality:

1. Schema extension parser correctly captures operations
1. Description printing matches reference implementation
1. Parser correctly errors on empty `extend` blocks
1. Parser correctly errors when disallowed descriptions are provided.