### PR TITLE
Fix issue with shadow variables in Swift 5.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        swift: ["5.5", "5.6"]
+        swift: ["5.4", "5.5", "5.6"]
     steps:
     - uses: swift-actions/setup-swift@v1
       with:


### PR DESCRIPTION
I was digging into why this PR failed in Swift 5.4: https://github.com/GraphQLSwift/Graphiti/pull/134 and noticed that the issue was actually in package. This PR fixes a shadow variable issue:

`Previous shadow copy into locations in the same scope!` https://github.com/GraphQLSwift/Graphiti/actions/runs/8103942873/job/22211259878?pr=134#step:4:238

Also added 5.4 as part of the GitHub workflow. 