### PR TITLE
Exposes `parse` and `print` functions

### DIFF
--- a/Sources/GraphQL/Language/Parser.swift
+++ b/Sources/GraphQL/Language/Parser.swift
@@ -2,7 +2,7 @@
  * Given a GraphQL source, parses it into a Document.
  * Throws GraphQLError if a syntax error is encountered.
  */
-func parse(
+public func parse(
     instrumentation: Instrumentation = NoOpInstrumentation,
     source: String,
     noLocation: Bool = false

--- a/Sources/GraphQL/Language/Printer.swift
+++ b/Sources/GraphQL/Language/Printer.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Converts an AST into a string, using one set of reasonable
 /// formatting rules.
-func print(ast: Node) -> String {
+public func print(ast: Node) -> String {
     ast.printed
 }
 

--- a/Sources/GraphQL/Subscription/EventStream.swift
+++ b/Sources/GraphQL/Subscription/EventStream.swift
@@ -27,7 +27,7 @@ open class EventStream<Element> {
             -> ConcurrentEventStream<To>
         {
             let newStream = stream.mapStream(closure)
-            return ConcurrentEventStream<To>.init(newStream)
+            return ConcurrentEventStream<To>(newStream)
         }
     }
 

--- a/Tests/GraphQLTests/SubscriptionTests/SimplePubSub.swift
+++ b/Tests/GraphQLTests/SubscriptionTests/SimplePubSub.swift
@@ -35,7 +35,7 @@ import GraphQL
                 )
                 subscribers.append(subscriber)
             }
-            return ConcurrentEventStream<T>.init(asyncStream)
+            return ConcurrentEventStream<T>(asyncStream)
         }
     }
 


### PR DESCRIPTION
This enables custom query parsing logic as well as printing SDLs for existing schemas. This could be helpful for federation support.