### PR TITLE
ci: Changes xcode version to latest stable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: latest
+        xcode-version: latest-stable
     - uses: actions/checkout@v3
     - name: Build and test
       run: swift test --parallel --enable-test-discovery

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
     name: Test on Linux
     runs-on: ubuntu-latest
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@v2
     - uses: actions/checkout@v3
     - name: Test
       run: swift test --parallel --enable-code-coverage
@@ -61,9 +61,9 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        swift: ["5.7", "5.8"]
+        swift: ["5.7", "5.8", "5.9", "5.10"]
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@v2
       with:
         swift-version: ${{ matrix.swift }}
     - uses: actions/checkout@v3
@@ -78,7 +78,7 @@ jobs:
       matrix:
         swift: ["5.4", "5.5", "5.6"]
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@v2
       with:
         swift-version: ${{ matrix.swift }}
     - uses: actions/checkout@v3


### PR DESCRIPTION
This changes the MacOS CI from using the `latest` XCode to `latest-stable` to avoid going to v16, which comes with Swift 6.0.0. This resolves the issues observed here: https://github.com/GraphQLSwift/Graphiti/pull/137#issuecomment-2177314720

It also adds Swift 5.9 and 5.10 to the Linux test matrix