### PR TITLE
Allows numeric values to be parsed as GraphQLBools

### DIFF
--- a/Sources/GraphQL/Type/Scalars.swift
+++ b/Sources/GraphQL/Type/Scalars.swift
@@ -201,6 +201,11 @@ public let GraphQLBoolean = try! GraphQLScalarType(
         if case let .bool(value) = inputValue {
             return inputValue
         }
+        // NOTE: We deviate from graphql-js and allow numeric conversions here because
+        // the MapCoder's round-trip conversion to NSObject for Bool converts to 0/1 numbers.
+        if case let .number(value) = inputValue {
+            return .bool(value.intValue != 0)
+        }
         throw GraphQLError(
             message: "Boolean cannot represent a non boolean value: \(inputValue)"
         )

--- a/Tests/GraphQLTests/TypeTests/ScalarTests.swift
+++ b/Tests/GraphQLTests/TypeTests/ScalarTests.swift
@@ -300,18 +300,12 @@ class ScalarTests: XCTestCase {
             GraphQLBoolean.parseValue(.null),
             "Boolean cannot represent a non boolean value: null"
         )
-        try XCTAssertThrowsError(
-            GraphQLBoolean.parseValue(0),
-            "Boolean cannot represent a non boolean value: 0"
-        )
-        try XCTAssertThrowsError(
-            GraphQLBoolean.parseValue(1),
-            "Boolean cannot represent a non boolean value: 1"
-        )
-        try XCTAssertThrowsError(
-            GraphQLBoolean.parseValue(.double(Double.nan)),
-            "Boolean cannot represent a non boolean value: NaN"
-        )
+        // NOTE: We deviate from graphql-js and allow numeric conversions here because
+        // the MapCoder's round-trip conversion to NSObject for Bool converts to 0/1 numbers.
+        try XCTAssertNoThrow(GraphQLBoolean.parseValue(0))
+        try XCTAssertNoThrow(GraphQLBoolean.parseValue(1))
+        try XCTAssertNoThrow(GraphQLBoolean.parseValue(.double(Double.nan)))
+
         try XCTAssertThrowsError(
             GraphQLBoolean.parseValue(""),
             #"Boolean cannot represent a non boolean value: """#


### PR DESCRIPTION
This is because MapCoder round-trips of Bools result in Number types. This is hard to avoid since it gets put into an NSObject container and there is no NSBool type.

Note that query validation will still disallow directly passing numeric values into boolean arguments as tested here: https://github.com/GraphQLSwift/GraphQL/blob/0dfa0d9b0ed3abb922632908e269186398bba8d3/Tests/GraphQLTests/ValidationTests/ValuesOfCorrectTypeRuleTests.swift#L412 Instead this simply allows numeric Swift map objects to be interpreted as GraphQLBool types.

Fixes https://github.com/GraphQLSwift/GraphQL/issues/155