### PR TITLE
Android support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,6 +56,14 @@ jobs:
         name: test-coverage-report
         path: .test-coverage
 
+  android:
+    name: Test on Android
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Test
+      uses: skiptools/swift-android-action@v2
+
   backcompat-ubuntu-22_04:
     name: Test Swift ${{ matrix.swift }} on Ubuntu 22.04
     runs-on: ubuntu-22.04

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "9bf03ff58ce34478e66aaee630e491823326fd06",
-        "version" : "1.1.3"
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "4c4453b489cf76e6b3b0f300aba663eb78182fad",
-        "version" : "2.70.0"
+        "revision" : "27c839f4700069928196cd0e9fa03b22f297078a",
+        "version" : "2.78.0"
       }
     },
     {

--- a/Sources/GraphQL/Instrumentation/Instrumentation.swift
+++ b/Sources/GraphQL/Instrumentation/Instrumentation.swift
@@ -62,7 +62,7 @@ public extension Instrumentation {
 }
 
 func threadId() -> Int {
-    #if os(Linux)
+    #if os(Linux) || os(Android)
         return Int(pthread_self())
     #else
         return Int(pthread_mach_thread_np(pthread_self()))

--- a/Sources/GraphQL/Map/AnyCoder.swift
+++ b/Sources/GraphQL/Map/AnyCoder.swift
@@ -2699,7 +2699,7 @@ private extension _AnyDecoder {
     func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }
 
-        #if DEPLOYMENT_RUNTIME_SWIFT || os(Linux)
+        #if DEPLOYMENT_RUNTIME_SWIFT || os(Linux) || os(Android)
             // Bridging differences require us to split implementations here
             guard let number = __SwiftValue.store(value) as? NSNumber else {
                 throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)

--- a/Sources/GraphQL/Map/MapCoder.swift
+++ b/Sources/GraphQL/Map/MapCoder.swift
@@ -2707,7 +2707,7 @@ private extension _MapDecoder {
     func unbox(_ value: Any, as type: Bool.Type) throws -> Bool? {
         guard !(value is NSNull) else { return nil }
 
-        #if DEPLOYMENT_RUNTIME_SWIFT || os(Linux)
+        #if DEPLOYMENT_RUNTIME_SWIFT || os(Linux) || os(Android)
             // Bridging differences require us to split implementations here
             guard let number = __SwiftValue.store(value) as? NSNumber else {
                 throw DecodingError._typeMismatch(at: codingPath, expectation: type, reality: value)

--- a/Tests/GraphQLTests/InstrumentationTests/InstrumentationTests.swift
+++ b/Tests/GraphQLTests/InstrumentationTests/InstrumentationTests.swift
@@ -148,7 +148,7 @@ class InstrumentationTests: XCTestCase, Instrumentation {
     }
 
     func testInstrumentationCalls() throws {
-//        #if os(Linux)
+//        #if os(Linux) || os(Android)
 //        expectedThreadId = Int(pthread_self())
 //        #else
 //        expectedThreadId = Int(pthread_mach_thread_np(pthread_self()))
@@ -172,7 +172,7 @@ class InstrumentationTests: XCTestCase, Instrumentation {
 
     func testDispatchQueueInstrumentationWrapper() throws {
 //        let dispatchGroup = DispatchGroup()
-//        #if os(Linux)
+//        #if os(Linux) || os(Android)
 //        expectedThreadId = Int(pthread_self())
 //        #else
 //        expectedThreadId = Int(pthread_mach_thread_np(pthread_self()))


### PR DESCRIPTION
This PR makes the minimal changes needed for Android support.

~It won't build for Android yet until a `swift-nio` release is cut that includes https://github.com/apple/swift-nio/pull/3033, but if you switch the `swift-nio` dependency to `branch: "main"`, test cases will pass (e.g., by running `skip android test` or using the [swift-android-action](https://github.com/marketplace/actions/swift-android-action) github action).~

It builds and passes all the tests on Android as of [swift-nio 2.78.0](https://github.com/apple/swift-nio/releases/tag/2.78.0) .