### PR TITLE
`GraphQLResult` marked Sendable

### DIFF
--- a/Sources/GraphQL/GraphQLRequest.swift
+++ b/Sources/GraphQL/GraphQLRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// A GraphQL request object, containing `query`, `operationName`, and `variables` fields
-public struct GraphQLRequest: Equatable, Codable {
+public struct GraphQLRequest: Equatable, Codable, Sendable {
     public var query: String
     public var operationName: String?
     public var variables: [String: Map]


### PR DESCRIPTION
This simply marks `GraphQLResult` as Sendable, which is convenient when conforming downstream APIs to strict concurrency.