### PR TITLE
fix: Adjust recursive cycle detection to fix EXC_BAD_ACCESS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.swift]
+indent_style = space
+indent_size = 4

--- a/Sources/GraphQL/Type/Validation.swift
+++ b/Sources/GraphQL/Type/Validation.swift
@@ -690,55 +690,7 @@ func validateOneOfInputObjectField(
 func createInputObjectCircularRefsValidator(
     context: SchemaValidationContext
 ) throws -> (GraphQLInputObjectType) throws -> Void {
-    // Modified copy of algorithm from 'src/validation/rules/NoFragmentCycles.js'.
-    // Tracks already visited types to maintain O(N) and to ensure that cycles
-    // are not redundantly reported.
-    var visitedTypes = Set<GraphQLInputObjectType>()
-
-    // Array of types nodes used to produce meaningful errors
-    var fieldPath: [InputObjectFieldDefinition] = []
-
-    // Position in the type path
-    var fieldPathIndexByTypeName: [String: Int] = [:]
-
-    return detectCycleRecursive
-
-    /// This does a straight-forward DFS to find cycles.
-    /// It does not terminate when a cycle is found but continues to explore
-    /// the graph to find all possible cycles.
-    func detectCycleRecursive(inputObj: GraphQLInputObjectType) throws {
-        if visitedTypes.contains(inputObj) {
-            return
-        }
-
-        visitedTypes.insert(inputObj)
-        fieldPathIndexByTypeName[inputObj.name] = fieldPath.count
-
-        let fields = try inputObj.getFields().values
-        for field in fields {
-            if let nonNullType = field.type as? GraphQLNonNull,
-                let fieldType = nonNullType.ofType as? GraphQLInputObjectType
-            {
-                let cycleIndex = fieldPathIndexByTypeName[fieldType.name]
-
-                fieldPath.append(field)
-                if let cycleIndex = cycleIndex {
-                    let cyclePath = fieldPath[cycleIndex..<fieldPath.count]
-                    let pathStr = cyclePath.map { fieldObj in fieldObj.name }.joined(separator: ".")
-                    context.reportError(
-                        message:
-                            "Cannot reference Input Object \"\(fieldType)\" within itself through a series of non-null fields: \"\(pathStr)\".",
-                        nodes: cyclePath.map { fieldObj in fieldObj.astNode }
-                    )
-                } else {
-                    try detectCycleRecursive(inputObj: fieldType)
-                }
-                fieldPath.removeLast()
-            }
-        }
-
-        fieldPathIndexByTypeName[inputObj.name] = nil
-    }
+    return CircularRefsValidator(context: context).validate
 }
 
 func getAllImplementsInterfaceNodes(
@@ -779,5 +731,50 @@ func getDeprecatedDirectiveNode(
 ) -> Directive? {
     return directives?.find { node in
         node.name.value == GraphQLDeprecatedDirective.name
+    }
+}
+
+private final class CircularRefsValidator {
+    private let context: SchemaValidationContext
+    private var visitedTypes: Set<GraphQLInputObjectType> = []
+    private var fieldPath: [InputObjectFieldDefinition] = []
+    private var fieldPathIndexByTypeName: [String: Int] = [:]
+
+    init(context: SchemaValidationContext) {
+        self.context = context
+    }
+
+    func validate(inputObj: GraphQLInputObjectType) throws {
+        if visitedTypes.contains(inputObj) {
+            return
+        }
+
+        visitedTypes.insert(inputObj)
+        fieldPathIndexByTypeName[inputObj.name] = fieldPath.count
+
+        let fields = try inputObj.getFields().values
+        for field in fields {
+            if
+                let nonNullType = field.type as? GraphQLNonNull,
+                let fieldType = nonNullType.ofType as? GraphQLInputObjectType
+            {
+                let cycleIndex = fieldPathIndexByTypeName[fieldType.name]
+
+                fieldPath.append(field)
+                if let cycleIndex = cycleIndex {
+                    let cyclePath = fieldPath[cycleIndex ..< fieldPath.count]
+                    let pathStr = cyclePath.map { fieldObj in fieldObj.name }.joined(separator: ".")
+                    context.reportError(
+                        message: "Cannot reference Input Object \"\(fieldType)\" within itself through a series of non-null fields: \"\(pathStr)\".",
+                        nodes: cyclePath.map { fieldObj in fieldObj.astNode }
+                    )
+                } else {
+                    try validate(inputObj: fieldType)
+                }
+                fieldPath.removeLast()
+            }
+        }
+
+        fieldPathIndexByTypeName[inputObj.name] = nil
     }
 }


### PR DESCRIPTION
Prev implementation triggered EXC_BAD_ACCESS exception on line 711

> `fieldPathIndexByTypeName[inputObj.name] = fieldPath.count` could not access `count` since `fieldPath` was `<uninitialized>` even tho it clearly was

This commit wraps this logic into a class so `createInputObjectCircularRefsValidator` function no longer mutably captures a value type

> [!Note]
>
> _I also added `.editorconfig` file, this will help potential contributors to avoid switching their default formatting to "4-spaces" while working on graphql package_