### PR TITLE
Removes two entry points for memory leaks

### DIFF
--- a/Sources/GraphQL/Language/AST.swift
+++ b/Sources/GraphQL/Language/AST.swift
@@ -91,7 +91,7 @@ public final class Token: @unchecked Sendable {
      * including ignored tokens. <SOF> is always the first node and <EOF>
      * the last.
      */
-    public let prev: Token?
+    public private(set) weak var prev: Token?
     public internal(set) var next: Token?
 
     init(

--- a/Sources/GraphQL/Validation/Validate.swift
+++ b/Sources/GraphQL/Validation/Validate.swift
@@ -50,14 +50,15 @@ func visit(
     typeInfo: TypeInfo,
     documentAST: Document
 ) -> [GraphQLError] {
-    let context = ValidationContext(schema: schema, ast: documentAST, typeInfo: typeInfo)
+    var errors = [GraphQLError]()
+    let context = ValidationContext(schema: schema, ast: documentAST, typeInfo: typeInfo, onError: { errors.append($0) })
     let visitors = rules.map { rule in rule(context) }
     // Visit the whole document with each instance of all provided rules.
     visit(
         root: documentAST,
         visitor: visitWithTypeInfo(typeInfo: typeInfo, visitor: visitInParallel(visitors: visitors))
     )
-    return context.errors
+    return errors
 }
 
 /// Utility function which asserts a SDL document is valid by throwing an error

--- a/Sources/GraphQL/Validation/ValidationContext.swift
+++ b/Sources/GraphQL/Validation/ValidationContext.swift
@@ -176,9 +176,10 @@ public final class ValidationContext: ASTValidationContext {
         recursiveVariableUsages = [:]
 
         super.init(ast: ast) { _ in }
-        onError = { error in
-            self.errors.append(error)
-        }
+    }
+
+    public override func report(error: GraphQLError) {
+        errors.append(error)
     }
 
     func getSchema() -> GraphQLSchema? {

--- a/Sources/GraphQL/Validation/ValidationContext.swift
+++ b/Sources/GraphQL/Validation/ValidationContext.swift
@@ -164,22 +164,16 @@ public typealias SDLValidationRule = @Sendable (SDLValidationContext) -> Visitor
 public final class ValidationContext: ASTValidationContext {
     public let schema: GraphQLSchema
     let typeInfo: TypeInfo
-    var errors: [GraphQLError]
     var variableUsages: [HasSelectionSet: [VariableUsage]]
     var recursiveVariableUsages: [OperationDefinition: [VariableUsage]]
 
-    init(schema: GraphQLSchema, ast: Document, typeInfo: TypeInfo) {
+    init(schema: GraphQLSchema, ast: Document, typeInfo: TypeInfo, onError: @escaping (GraphQLError) -> Void) {
         self.schema = schema
         self.typeInfo = typeInfo
-        errors = []
         variableUsages = [:]
         recursiveVariableUsages = [:]
 
-        super.init(ast: ast) { _ in }
-    }
-
-    public override func report(error: GraphQLError) {
-        errors.append(error)
+        super.init(ast: ast, onError: onError) 
     }
 
     func getSchema() -> GraphQLSchema? {

--- a/Tests/GraphQLTests/GraphQLMemoryRetentionTests.swift
+++ b/Tests/GraphQLTests/GraphQLMemoryRetentionTests.swift
@@ -1,0 +1,65 @@
+import Testing
+
+@testable import GraphQL
+
+// Holds a weak reference to a Token so we can observe when ARC frees it.
+private final class WeakTokenBox {
+    weak var token: Token?
+}
+
+@Suite struct GraphQLMemoryRetentionTests {
+    private func makeSchema() throws -> GraphQLSchema {
+        try GraphQLSchema(
+            query: GraphQLObjectType(
+                name: "Query",
+                fields: ["hello": GraphQLField(type: GraphQLString)]
+            )
+        )
+    }
+
+    // Regression test for Token.prev being a strong reference.
+    //
+    // Adjacent tokens in the linked list formed a mutual retain cycle:
+    // SOF.next → T1 and T1.prev → SOF. When the Document went out of scope,
+    // neither token could be freed. Making prev `weak` breaks the cycle.
+    @Test func tokenChainIsReleasedAfterDocumentGoesOutOfScope() throws {
+        let box = WeakTokenBox()
+
+        func parseAndCapture() throws {
+            let document = try parse(source: "{ hello }")
+            // startToken is SOF (no prev). Capture the next token, which
+            // has a .prev back to SOF — the exact edge the fix targets.
+            box.token = document.loc?.startToken.next
+            #expect(box.token != nil)
+        }
+
+        try parseAndCapture()
+        #expect(box.token == nil)
+    }
+
+    // Regression test for ValidationContext.init capturing `self` in a closure.
+    //
+    // The onError closure stored on ASTValidationContext captured ValidationContext
+    // strongly, creating a cycle that prevented the context (and the Document it
+    // holds) from ever being freed. Overriding report(error:) instead eliminates
+    // the closure and the cycle.
+    //
+    // SOF (startToken) has no .prev, so it has no token-chain cycle. If it is
+    // retained after this scope it must be because ValidationContext leaked and
+    // is still holding a copy of the Document.
+    @Test func validationContextReleasesDocumentAfterValidation() throws {
+        let schema = try makeSchema()
+        let box = WeakTokenBox()
+
+        func validateAndCapture() throws {
+            let document = try parse(source: "{ hello }")
+            box.token = document.loc?.startToken  // SOF — no prev, no token cycle
+            let errors = validate(schema: schema, ast: document)
+            #expect(errors.isEmpty)
+            #expect(box.token != nil)
+        }
+
+        try validateAndCapture()
+        #expect(box.token == nil)
+    }
+}


### PR DESCRIPTION
Updates `Token.prev` to be a weak var to prevent memory leaks caused by reference cycles in the AST.

Updates `ValidationContext` to use an override of `report(error: GraphQLError)` rather than capturing itself strongly in the `onError` closure.

Adds `GraphQLMemoryRetentionTests.swift` with two regression tests to validate these changes remove these leaks.