### PR TITLE
`validateSchema` no longer throws

### DIFF
--- a/Sources/GraphQL/GraphQL.swift
+++ b/Sources/GraphQL/GraphQL.swift
@@ -36,7 +36,7 @@ public func graphql(
     validationRules: [@Sendable (ValidationContext) -> Visitor] = specifiedRules
 ) async throws -> GraphQLResult {
     // Validate schema
-    let schemaValidationErrors = try validateSchema(schema: schema)
+    let schemaValidationErrors = validateSchema(schema: schema)
     guard schemaValidationErrors.isEmpty else {
         return GraphQLResult(errors: schemaValidationErrors)
     }

--- a/Sources/GraphQL/Type/Validation.swift
+++ b/Sources/GraphQL/Type/Validation.swift
@@ -1,3 +1,5 @@
+import OrderedCollections
+
 /// Implements the "Type Validation" sub-sections of the specification's
 /// "Type System" section.
 ///
@@ -5,7 +7,7 @@
 /// an empty array if no errors were encountered and the Schema is valid.
 public func validateSchema(
     schema: GraphQLSchema
-) throws -> [GraphQLError] {
+) -> [GraphQLError] {
     // If this Schema has already been validated, return the previous results.
     if let validationErrors = schema.validationErrors {
         return validationErrors
@@ -15,7 +17,7 @@ public func validateSchema(
     let context = SchemaValidationContext(schema: schema)
     validateRootTypes(context: context)
     validateDirectives(context: context)
-    try validateTypes(context: context)
+    validateTypes(context: context)
 
     // Persist the results of validation before returning to ensure validation
     // does not run multiple times for this schema.
@@ -27,7 +29,7 @@ public func validateSchema(
 /// Utility function which asserts a schema is valid by throwing an error if
 /// it is invalid.
 func assertValidSchema(schema: GraphQLSchema) throws {
-    let errors = try validateSchema(schema: schema)
+    let errors = validateSchema(schema: schema)
     if !errors.isEmpty {
         throw GraphQLError(message: errors.map { error in error.message }.joined(separator: "\n\n"))
     }
@@ -166,9 +168,9 @@ func validateName(
     }
 }
 
-func validateTypes(context: SchemaValidationContext) throws {
+func validateTypes(context: SchemaValidationContext) {
     let validateInputObjectCircularRefs =
-        try createInputObjectCircularRefsValidator(context: context)
+        createInputObjectCircularRefsValidator(context: context)
     let typeMap = context.schema.typeMap
     for type in typeMap.values {
         var astNode: Node?
@@ -177,23 +179,23 @@ func validateTypes(context: SchemaValidationContext) throws {
             astNode = type.astNode
 
             // Ensure fields are valid
-            try validateFields(context: context, type: type)
+            validateFields(context: context, type: type)
 
             // Ensure objects implement the interfaces they claim to.
-            try validateInterfaces(context: context, type: type)
+            validateInterfaces(context: context, type: type)
         } else if let type = type as? GraphQLInterfaceType {
             astNode = type.astNode
 
             // Ensure fields are valid.
-            try validateFields(context: context, type: type)
+            validateFields(context: context, type: type)
 
             // Ensure interfaces implement the interfaces they claim to.
-            try validateInterfaces(context: context, type: type)
+            validateInterfaces(context: context, type: type)
         } else if let type = type as? GraphQLUnionType {
             astNode = type.astNode
 
             // Ensure Unions include valid member types.
-            try validateUnionMembers(context: context, union: type)
+            validateUnionMembers(context: context, union: type)
         } else if let type = type as? GraphQLEnumType {
             astNode = type.astNode
 
@@ -203,10 +205,10 @@ func validateTypes(context: SchemaValidationContext) throws {
             astNode = type.astNode
 
             // Ensure Input Object fields are valid.
-            try validateInputFields(context: context, inputObj: type)
+            validateInputFields(context: context, inputObj: type)
 
             // Ensure Input Objects do not contain non-nullable circular references
-            try validateInputObjectCircularRefs(type)
+            validateInputObjectCircularRefs(type)
         } else if let type = type as? GraphQLScalarType {
             astNode = type.astNode
         }
@@ -221,8 +223,14 @@ func validateTypes(context: SchemaValidationContext) throws {
 func validateFields(
     context: SchemaValidationContext,
     type: GraphQLObjectType
-) throws {
-    let fields = try type.getFields()
+) {
+    let fields: GraphQLFieldDefinitionMap
+    do {
+        fields = try type.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: type.astNode)
+        return
+    }
 
     // Objects and Interfaces both must define one or more fields.
     if fields.count == 0 {
@@ -268,8 +276,14 @@ func validateFields(
 func validateFields(
     context: SchemaValidationContext,
     type: GraphQLInterfaceType
-) throws {
-    let fields = try type.getFields()
+) {
+    let fields: GraphQLFieldDefinitionMap
+    do {
+        fields = try type.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: type.astNode)
+        return
+    }
 
     // Objects and Interfaces both must define one or more fields.
     if fields.count == 0 {
@@ -315,9 +329,16 @@ func validateFields(
 func validateInterfaces(
     context: SchemaValidationContext,
     type: GraphQLObjectType
-) throws {
+) {
     var ifaceTypeNames = Set<String>()
-    for iface in try type.getInterfaces() {
+    let interfaces: [GraphQLInterfaceType]
+    do {
+        interfaces = try type.getInterfaces()
+    } catch {
+        context.reportError(message: "Unable to get interfaces: \(error)", node: type.astNode)
+        return
+    }
+    for iface in interfaces {
         if type == iface {
             context.reportError(
                 message:
@@ -337,17 +358,24 @@ func validateInterfaces(
 
         ifaceTypeNames.insert(iface.name)
 
-        try validateTypeImplementsAncestors(context: context, type: type, iface: iface)
-        try validateTypeImplementsInterface(context: context, type: type, iface: iface)
+        validateTypeImplementsAncestors(context: context, type: type, iface: iface)
+        validateTypeImplementsInterface(context: context, type: type, iface: iface)
     }
 }
 
 func validateInterfaces(
     context: SchemaValidationContext,
     type: GraphQLInterfaceType
-) throws {
+) {
     var ifaceTypeNames = Set<String>()
-    for iface in try type.getInterfaces() {
+    let interfaces: [GraphQLInterfaceType]
+    do {
+        interfaces = try type.getInterfaces()
+    } catch {
+        context.reportError(message: "Unable to get interfaces: \(error)", node: type.astNode)
+        return
+    }
+    for iface in interfaces {
         if type == iface {
             context.reportError(
                 message:
@@ -367,8 +395,8 @@ func validateInterfaces(
 
         ifaceTypeNames.insert(iface.name)
 
-        try validateTypeImplementsAncestors(context: context, type: type, iface: iface)
-        try validateTypeImplementsInterface(context: context, type: type, iface: iface)
+        validateTypeImplementsAncestors(context: context, type: type, iface: iface)
+        validateTypeImplementsInterface(context: context, type: type, iface: iface)
     }
 }
 
@@ -376,11 +404,24 @@ func validateTypeImplementsInterface(
     context: SchemaValidationContext,
     type: GraphQLObjectType,
     iface: GraphQLInterfaceType
-) throws {
-    let typeFieldMap = try type.getFields()
+) {
+    let typeFieldMap: GraphQLFieldDefinitionMap
+    do {
+        typeFieldMap = try type.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: type.astNode)
+        return
+    }
+    let ifaceFields: OrderedDictionary<String, GraphQLFieldDefinition>
+    do {
+        ifaceFields = try iface.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: iface.astNode)
+        return
+    }
 
     // Assert each interface field is implemented.
-    for ifaceField in try iface.getFields().values {
+    for ifaceField in ifaceFields.values {
         let fieldName = ifaceField.name
         let typeField = typeFieldMap[fieldName]
 
@@ -398,7 +439,7 @@ func validateTypeImplementsInterface(
 
         // Assert interface field type is satisfied by type field type, by being
         // a valid subtype. (covariant)
-        if try !isTypeSubTypeOf(context.schema, typeField.type, ifaceField.type) {
+        if !isTypeSubTypeOf(context.schema, typeField.type, ifaceField.type) {
             context.reportError(
                 message: "Interface field \(iface.name).\(fieldName) expects type "
                     + "\(ifaceField.type) but \(type).\(fieldName) " + "is type \(typeField.type).",
@@ -456,11 +497,24 @@ func validateTypeImplementsInterface(
     context: SchemaValidationContext,
     type: GraphQLInterfaceType,
     iface: GraphQLInterfaceType
-) throws {
-    let typeFieldMap = try type.getFields()
+) {
+    let typeFieldMap: GraphQLFieldDefinitionMap
+    do {
+        typeFieldMap = try type.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: type.astNode)
+        return
+    }
+    let ifaceFields: OrderedDictionary<String, GraphQLFieldDefinition>
+    do {
+        ifaceFields = try iface.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: iface.astNode)
+        return
+    }
 
     // Assert each interface field is implemented.
-    for ifaceField in try iface.getFields().values {
+    for ifaceField in ifaceFields.values {
         let fieldName = ifaceField.name
         let typeField = typeFieldMap[fieldName]
 
@@ -478,7 +532,7 @@ func validateTypeImplementsInterface(
 
         // Assert interface field type is satisfied by type field type, by being
         // a valid subtype. (covariant)
-        if try !isTypeSubTypeOf(context.schema, typeField.type, ifaceField.type) {
+        if !isTypeSubTypeOf(context.schema, typeField.type, ifaceField.type) {
             context.reportError(
                 message: "Interface field \(iface.name).\(fieldName) expects type "
                     + "\(ifaceField.type) but \(type).\(fieldName) " + "is type \(typeField.type).",
@@ -536,9 +590,17 @@ func validateTypeImplementsAncestors(
     context: SchemaValidationContext,
     type: GraphQLObjectType,
     iface: GraphQLInterfaceType
-) throws {
-    let ifaceInterfaces = try type.getInterfaces()
-    for transitive in try iface.getInterfaces() {
+) {
+    let ifaceInterfaces: [GraphQLInterfaceType]
+    let transitives: [GraphQLInterfaceType]
+    do {
+        ifaceInterfaces = try type.getInterfaces()
+        transitives = try iface.getInterfaces()
+    } catch {
+        context.reportError(message: "Unable to get interfaces: \(error)", node: type.astNode)
+        return
+    }
+    for transitive in transitives {
         if !ifaceInterfaces.contains(transitive) {
             var nodes: [Node?] = getAllImplementsInterfaceNodes(type: iface, iface: transitive)
             nodes.append(contentsOf: getAllImplementsInterfaceNodes(type: type, iface: iface))
@@ -556,9 +618,17 @@ func validateTypeImplementsAncestors(
     context: SchemaValidationContext,
     type: GraphQLInterfaceType,
     iface: GraphQLInterfaceType
-) throws {
-    let ifaceInterfaces = try type.getInterfaces()
-    for transitive in try iface.getInterfaces() {
+) {
+    let ifaceInterfaces: [GraphQLInterfaceType]
+    let transitives: [GraphQLInterfaceType]
+    do {
+        ifaceInterfaces = try type.getInterfaces()
+        transitives = try iface.getInterfaces()
+    } catch {
+        context.reportError(message: "Unable to get interfaces: \(error)", node: type.astNode)
+        return
+    }
+    for transitive in transitives {
         if !ifaceInterfaces.contains(transitive) {
             var nodes: [Node?] = getAllImplementsInterfaceNodes(type: iface, iface: transitive)
             nodes.append(contentsOf: getAllImplementsInterfaceNodes(type: type, iface: iface))
@@ -575,8 +645,14 @@ func validateTypeImplementsAncestors(
 func validateUnionMembers(
     context: SchemaValidationContext,
     union: GraphQLUnionType
-) throws {
-    let memberTypes = try union.getTypes()
+) {
+    let memberTypes: [GraphQLObjectType]
+    do {
+        memberTypes = try union.getTypes()
+    } catch {
+        context.reportError(message: "Unable to get types: \(error)", node: union.astNode)
+        return
+    }
 
     if memberTypes.count == 0 {
         var nodes: [Node?] = [union.astNode]
@@ -624,8 +700,14 @@ func validateEnumValues(
 func validateInputFields(
     context: SchemaValidationContext,
     inputObj: GraphQLInputObjectType
-) throws {
-    let fields = try inputObj.getFields().values
+) {
+    let fields: OrderedDictionary<String, InputObjectFieldDefinition>
+    do {
+        fields = try inputObj.getFields()
+    } catch {
+        context.reportError(message: "Unable to get fields: \(error)", node: inputObj.astNode)
+        return
+    }
 
     if fields.count == 0 {
         var nodes: [Node?] = [inputObj.astNode]
@@ -637,7 +719,7 @@ func validateInputFields(
     }
 
     // Ensure the arguments are valid
-    for field in fields {
+    for field in fields.values {
         // Ensure they are named correctly.
         validateName(context: context, name: field.name, astNode: field.astNode)
 
@@ -689,7 +771,7 @@ func validateOneOfInputObjectField(
 
 func createInputObjectCircularRefsValidator(
     context: SchemaValidationContext
-) throws -> (GraphQLInputObjectType) throws -> Void {
+) -> (GraphQLInputObjectType) -> Void {
     return CircularRefsValidator(context: context).validate
 }
 
@@ -744,7 +826,7 @@ private final class CircularRefsValidator {
         self.context = context
     }
 
-    func validate(inputObj: GraphQLInputObjectType) throws {
+    func validate(inputObj: GraphQLInputObjectType) {
         if visitedTypes.contains(inputObj) {
             return
         }
@@ -752,24 +834,31 @@ private final class CircularRefsValidator {
         visitedTypes.insert(inputObj)
         fieldPathIndexByTypeName[inputObj.name] = fieldPath.count
 
-        let fields = try inputObj.getFields().values
-        for field in fields {
-            if
-                let nonNullType = field.type as? GraphQLNonNull,
+        let fields: OrderedDictionary<String, InputObjectFieldDefinition>
+        do {
+            fields = try inputObj.getFields()
+        } catch {
+            context.reportError(message: "Unable to get fields: \(error)", node: inputObj.astNode)
+            return
+        }
+
+        for field in fields.values {
+            if let nonNullType = field.type as? GraphQLNonNull,
                 let fieldType = nonNullType.ofType as? GraphQLInputObjectType
             {
                 let cycleIndex = fieldPathIndexByTypeName[fieldType.name]
 
                 fieldPath.append(field)
                 if let cycleIndex = cycleIndex {
-                    let cyclePath = fieldPath[cycleIndex ..< fieldPath.count]
+                    let cyclePath = fieldPath[cycleIndex..<fieldPath.count]
                     let pathStr = cyclePath.map { fieldObj in fieldObj.name }.joined(separator: ".")
                     context.reportError(
-                        message: "Cannot reference Input Object \"\(fieldType)\" within itself through a series of non-null fields: \"\(pathStr)\".",
+                        message:
+                            "Cannot reference Input Object \"\(fieldType)\" within itself through a series of non-null fields: \"\(pathStr)\".",
                         nodes: cyclePath.map { fieldObj in fieldObj.astNode }
                     )
                 } else {
-                    try validate(inputObj: fieldType)
+                    validate(inputObj: fieldType)
                 }
                 fieldPath.removeLast()
             }

--- a/Sources/GraphQL/Utilities/TypeComparators.swift
+++ b/Sources/GraphQL/Utilities/TypeComparators.swift
@@ -66,7 +66,7 @@ func isTypeSubTypeOf(
     _ schema: GraphQLSchema,
     _ maybeSubType: GraphQLType,
     _ superType: GraphQLType
-) throws -> Bool {
+) -> Bool {
     // Equivalent type is a valid subtype
     if maybeSubType == superType {
         return true
@@ -75,19 +75,19 @@ func isTypeSubTypeOf(
     // If superType is non-null, maybeSubType must also be non-null.
     if let superType = superType as? GraphQLNonNull {
         if let maybeSubType = maybeSubType as? GraphQLNonNull {
-            return try isTypeSubTypeOf(schema, maybeSubType.ofType, superType.ofType)
+            return isTypeSubTypeOf(schema, maybeSubType.ofType, superType.ofType)
         }
 
         return false
     } else if let maybeSubType = maybeSubType as? GraphQLNonNull {
         // If superType is nullable, maybeSubType may be non-null or nullable.
-        return try isTypeSubTypeOf(schema, maybeSubType.ofType, superType)
+        return isTypeSubTypeOf(schema, maybeSubType.ofType, superType)
     }
 
     // If superType type is a list, maybeSubType type must also be a list.
     if let superType = superType as? GraphQLList {
         if let maybeSubType = maybeSubType as? GraphQLList {
-            return try isTypeSubTypeOf(schema, maybeSubType.ofType, superType.ofType)
+            return isTypeSubTypeOf(schema, maybeSubType.ofType, superType.ofType)
         }
 
         return false

--- a/Sources/GraphQL/Validation/Rules/VariablesInAllowedPositionRule.swift
+++ b/Sources/GraphQL/Validation/Rules/VariablesInAllowedPositionRule.swift
@@ -35,14 +35,13 @@ func VariablesInAllowedPositionRule(context: ValidationContext) -> Visitor {
                         // the variable type is non-null when the expected type is nullable.
                         // If both are list types, the variable item type can be more strict
                         // than the expected item type (contravariant).
-                        let isAllowed =
-                            (try? allowedVariableUsage(
-                                schema: schema,
-                                varType: varType,
-                                varDefaultValue: varDef.defaultValue,
-                                locationType: type,
-                                locationDefaultValue: usage.defaultValue
-                            )) ?? false
+                        let isAllowed = allowedVariableUsage(
+                            schema: schema,
+                            varType: varType,
+                            varDefaultValue: varDef.defaultValue,
+                            locationType: type,
+                            locationDefaultValue: usage.defaultValue
+                        )
                         if !isAllowed {
                             context.report(
                                 error: GraphQLError(
@@ -71,7 +70,7 @@ func allowedVariableUsage(
     varDefaultValue: Value?,
     locationType: GraphQLType,
     locationDefaultValue: Map?
-) throws -> Bool {
+) -> Bool {
     if let locationType = locationType as? GraphQLNonNull, !(varType is GraphQLNonNull) {
         let hasNonNullVariableDefaultValue =
             varDefaultValue != nil
@@ -82,7 +81,7 @@ func allowedVariableUsage(
             return false
         }
         let nullableLocationType = locationType.ofType
-        return try isTypeSubTypeOf(schema, varType, nullableLocationType)
+        return isTypeSubTypeOf(schema, varType, nullableLocationType)
     }
-    return try isTypeSubTypeOf(schema, varType, locationType)
+    return isTypeSubTypeOf(schema, varType, locationType)
 }

--- a/Tests/GraphQLTests/TypeTests/ValidateSchemaTests.swift
+++ b/Tests/GraphQLTests/TypeTests/ValidateSchemaTests.swift
@@ -86,7 +86,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
 
         let schemaWithDef = try buildSchema(
             source: """
@@ -99,7 +99,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schemaWithDef) == [])
+        #expect(validateSchema(schema: schemaWithDef) == [])
     }
 
     @Test func acceptsASchemaWhoseQueryAndMutationTypesAreObjectTypes() throws {
@@ -114,7 +114,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
 
         let schemaWithDef = try buildSchema(
             source: """
@@ -132,7 +132,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schemaWithDef) == [])
+        #expect(validateSchema(schema: schemaWithDef) == [])
     }
 
     @Test func acceptsASchemaWhoseQueryAndSubscriptionTypesAreObjectTypes() throws {
@@ -147,7 +147,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
 
         let schemaWithDef = try buildSchema(
             source: """
@@ -165,7 +165,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schemaWithDef) == [])
+        #expect(validateSchema(schema: schemaWithDef) == [])
     }
 
     @Test func rejectsASchemaWithoutAQueryType() throws {
@@ -176,7 +176,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(message: "Query root type must be provided.")
             ]
@@ -193,7 +193,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schemaWithDef) == [
                 GraphQLError(
                     message: "Query root type must be provided.",
@@ -391,7 +391,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
             query: SomeObjectType,
             directives: [badDirective]
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(message: "Directive @BadDirective must include 1 or more locations.")
             ]
@@ -422,7 +422,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsASchemaWhereTheSameTypeIsUsedForMultipleRootTypes() throws {
@@ -444,7 +444,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -473,7 +473,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -502,7 +502,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnObjectTypeWithMissingFields() throws {
@@ -515,7 +515,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   type IncompleteObject
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "Type IncompleteObject must define one or more fields.",
@@ -530,7 +530,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 fields: [:]
             )
         )
-        try #expect(
+        #expect(
             validateSchema(schema: manualSchema) == [
                 GraphQLError(message: "Type IncompleteObject must define one or more fields.")
             ]
@@ -545,7 +545,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     }
                 )
         )
-        try #expect(
+        #expect(
             validateSchema(schema: manualSchema2) == [
                 GraphQLError(message: "Type IncompleteObject must define one or more fields.")
             ]
@@ -562,7 +562,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     }
                 )
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -589,7 +589,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     ]
                 )
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsFieldArgWithInvalidNames() throws {
@@ -608,7 +608,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 )
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -640,7 +640,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     | TypeB
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAUnionTypeWithEmptyTypes() throws {
@@ -665,7 +665,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
             )
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "Union type BadUnion must define one or more member types.",
@@ -700,7 +700,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "Union type BadUnion can only include type TypeA once.",
@@ -717,7 +717,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
             documentAST: parse(source: "extend union BadUnion = TypeB")
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "Union type BadUnion can only include type TypeA once.",
@@ -751,7 +751,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnInputObjectTypeWithMissingFields() throws {
@@ -776,7 +776,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
             )
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -811,7 +811,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnInputObjectWithNonBreakableCircularReference() throws {
@@ -827,7 +827,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -859,7 +859,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -897,7 +897,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -965,7 +965,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1003,7 +1003,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
             )
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "Enum type SomeEnum must define one or more values.",
@@ -1027,7 +1027,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 )
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1120,7 +1120,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "Type AnotherObject can only implement AnotherInterface once.",
@@ -1153,7 +1153,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
             schema: schema,
             documentAST: parse(source: "extend type AnotherObject implements AnotherInterface")
         )
-        try #expect(
+        #expect(
             validateSchema(schema: extendedSchema) == [
                 GraphQLError(
                     message: "Type AnotherObject can only implement AnotherInterface once.",
@@ -1198,7 +1198,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     """
             )
         )
-        try #expect(
+        #expect(
             validateSchema(schema: extendedSchema) == [
                 GraphQLError(
                     message:
@@ -1243,7 +1243,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     """
             )
         )
-        try #expect(
+        #expect(
             validateSchema(schema: extendedSchema) == [
                 GraphQLError(
                     message:
@@ -1301,7 +1301,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                     """
             )
         )
-        try #expect(
+        #expect(
             validateSchema(schema: extendedSchema) == [
                 GraphQLError(
                     message:
@@ -1345,7 +1345,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
     @Test func acceptsAnOutputTypeAsAnInterfaceFieldType() throws {
         for type in outputTypes {
             let schema = try schemaWithInterfaceField(fieldConfig: .init(type: type))
-            try #expect(validateSchema(schema: schema) == [])
+            #expect(validateSchema(schema: schema) == [])
         }
     }
 
@@ -1388,7 +1388,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     // MARK: Type System: Arguments must have input types
@@ -1428,7 +1428,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
     @Test func acceptsAnInputTypeAsAFieldArgType() throws {
         for type in inputTypes {
             let schema = try schemaWithArg(argConfig: .init(type: type))
-            try #expect(validateSchema(schema: schema) == [])
+            #expect(validateSchema(schema: schema) == [])
         }
     }
 
@@ -1450,7 +1450,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1520,7 +1520,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
     @Test func acceptsAnInputTypeAsAnInputFieldType() throws {
         for type in inputTypes {
             let schema = try schemaWithInputField(inputFieldConfig: .init(type: type))
-            try #expect(validateSchema(schema: schema) == [])
+            #expect(validateSchema(schema: schema) == [])
         }
     }
 
@@ -1562,7 +1562,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "OneOf input field SomeInputObject.b must be nullable.",
@@ -1585,7 +1585,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message: "OneOf input field SomeInputObject.b cannot have a default value.",
@@ -1613,7 +1613,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func acceptsAnObjectWhichImplementsAnInterfaceAlongWithMoreFields() throws {
@@ -1633,7 +1633,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func acceptsAnObjectWhichImplementsAnInterfaceFieldAlongWithAdditionalOptionalArguments()
@@ -1654,7 +1654,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnObjectMissingAnInterfaceField() throws {
@@ -1673,7 +1673,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1703,7 +1703,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1736,7 +1736,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1766,7 +1766,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func acceptsAnObjectWithASubtypedInterfaceField_Union() throws {
@@ -1791,7 +1791,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnObjectMissingAnInterfaceArgument() throws {
@@ -1810,7 +1810,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1840,7 +1840,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1870,7 +1870,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1915,7 +1915,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1945,7 +1945,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnObjectWithANonlistInterfaceFieldListType() throws {
@@ -1964,7 +1964,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -1994,7 +1994,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2024,7 +2024,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnObjectWithASupersetNullableInterfaceFieldType() throws {
@@ -2043,7 +2043,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2077,7 +2077,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2109,7 +2109,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func acceptsAnInterfaceWhichImplementsAnInterfaceAlongWithMoreFields() throws {
@@ -2129,7 +2129,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test
@@ -2151,7 +2151,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnInterfaceMissingAnInterfaceField() throws {
@@ -2170,7 +2170,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2200,7 +2200,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2233,7 +2233,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2263,7 +2263,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func acceptsAnInterfaceWithASubtypedInterfaceField_Union() throws {
@@ -2288,7 +2288,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnInterfaceImplementingANoninterfaceType() throws {
@@ -2330,7 +2330,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2360,7 +2360,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2390,7 +2390,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2436,7 +2436,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2466,7 +2466,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnInterfaceWithANonlistInterfaceFieldListType() throws {
@@ -2485,7 +2485,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2515,7 +2515,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2545,7 +2545,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(validateSchema(schema: schema) == [])
+        #expect(validateSchema(schema: schema) == [])
     }
 
     @Test func rejectsAnInterfaceWithASupersetNullableInterfaceFieldType() throws {
@@ -2564,7 +2564,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2598,7 +2598,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                   }
                 """
         )
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2625,7 +2625,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:
@@ -2653,7 +2653,7 @@ func schemaWithFieldType(type: GraphQLOutputType) throws -> GraphQLSchema {
                 """
         )
 
-        try #expect(
+        #expect(
             validateSchema(schema: schema) == [
                 GraphQLError(
                     message:

--- a/Tests/GraphQLTests/UtilitiesTests/BuildASTSchemaTests.swift
+++ b/Tests/GraphQLTests/UtilitiesTests/BuildASTSchemaTests.swift
@@ -1105,7 +1105,7 @@ import Testing
 
     @Test func canBuildInvalidSchema() throws {
         let schema = try buildSchema(source: "type Mutation")
-        let errors = try validateSchema(schema: schema)
+        let errors = validateSchema(schema: schema)
         #expect(errors.count > 0)
     }
 

--- a/Tests/GraphQLTests/UtilitiesTests/ExtendSchemaTests.swift
+++ b/Tests/GraphQLTests/UtilitiesTests/ExtendSchemaTests.swift
@@ -158,7 +158,7 @@ import Testing
             documentAST: parse(source: extensionSDL)
         )
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == #"""
                 type SomeObject implements AnotherInterface & SomeInterface {
@@ -199,7 +199,7 @@ import Testing
         let someScalar =
             try #require((extendedSchema.getType(name: "SomeScalar") as? GraphQLScalarType))
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         #expect(extensionASTNodes(someScalar.extensionASTNodes) == extensionSDL)
     }
 
@@ -229,7 +229,7 @@ import Testing
 
         #expect(foo.specifiedByURL == "https://example.com/foo_spec")
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         #expect(extensionASTNodes(foo.extensionASTNodes) == extensionSDL)
     }
 
@@ -545,7 +545,7 @@ import Testing
             documentAST: parse(source: extensionSDL)
         )
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == extensionSDL
         )
@@ -576,7 +576,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 type SomeObject {
@@ -612,7 +612,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 type SomeObject {
@@ -645,7 +645,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 type SomeObject implements SomeInterface {
@@ -699,7 +699,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 type SomeObject {
@@ -746,7 +746,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 type SomeObject implements OldInterface & NewInterface {
@@ -857,7 +857,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schemaWithNewTypes, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 scalar SomeScalar @specifiedBy(url: "http://example.com/foo_spec")
@@ -924,7 +924,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 interface SomeInterface {
@@ -982,7 +982,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 interface AnotherInterface implements SomeInterface & NewInterface {
@@ -1027,7 +1027,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema).count > 0)
+        #expect(validateSchema(schema: extendedSchema).count > 0)
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 interface SomeInterface {
@@ -1063,7 +1063,7 @@ import Testing
         )
         let extendedSchema = try extendSchema(schema: schema, documentAST: extendAST)
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == """
                 interface SomeInterface {
@@ -1147,7 +1147,7 @@ import Testing
             documentAST: parse(source: extensionSDL)
         )
 
-        try #expect(validateSchema(schema: extendedSchema) == [])
+        #expect(validateSchema(schema: extendedSchema) == [])
         try #expect(
             schemaChanges(schema, extendedSchema) == extensionSDL
         )


### PR DESCRIPTION
This simplifies the downstream handling of errors by avoiding a separate error handling step outside of the direct results.

This is considered a *minor* semver change, because removing `throws` from a function signature will cause a `warning: no calls to throwing functions occur within 'try' expression`, but will not break compilation.